### PR TITLE
Update AWS Auth

### DIFF
--- a/codebundles/aws-c7n-acm-health/.runwhen/templates/aws-c7n-acm-health-sli.yaml
+++ b/codebundles/aws-c7n-acm-health/.runwhen/templates/aws-c7n-acm-health-sli.yaml
@@ -32,10 +32,7 @@ spec:
     - name: AWS_ACCOUNT_ID
       value: "{{match_resource.resource.account_id}}"
   secretsProvided:
-    - name: AWS_ACCESS_KEY_ID
-      workspaceKey: {{custom.aws_access_key_id}}
-    - name: AWS_SECRET_ACCESS_KEY
-      workspaceKey: {{custom.aws_secret_access_key}}
+    {% include "aws-auth.yaml" ignore missing %}
   alerts:
     warning:
       operator: <

--- a/codebundles/aws-c7n-acm-health/.runwhen/templates/aws-c7n-acm-health-taskset.yaml
+++ b/codebundles/aws-c7n-acm-health/.runwhen/templates/aws-c7n-acm-health-taskset.yaml
@@ -27,7 +27,4 @@ spec:
     - name: AWS_ACCOUNT_ID
       value: "{{match_resource.resource.account_id}}"
   secretsProvided:
-    - name: AWS_ACCESS_KEY_ID
-      workspaceKey: {{custom.aws_access_key_id}}
-    - name: AWS_SECRET_ACCESS_KEY
-      workspaceKey: {{custom.aws_secret_access_key}}
+    {% include "aws-auth.yaml" ignore missing %}

--- a/codebundles/aws-c7n-acm-health/runbook.robot
+++ b/codebundles/aws-c7n-acm-health/runbook.robot
@@ -14,11 +14,10 @@ Suite Setup    Suite Initialization
 *** Tasks ***
 List Unused ACM Certificates in AWS Region `${AWS_REGION}` in AWS Account `${AWS_ACCOUNT_ID}`
     [Documentation]  Find unused ACM certificates
-    [Tags]    aws    acm    certificate    security 
+    [Tags]    aws    acm    certificate    security    data:config
     ${c7n_output}=    RW.CLI.Run Cli
     ...    cmd=custodian run -r ${AWS_REGION} --output-dir ${OUTPUT_DIR}/aws-c7n-acm-health ${CURDIR}/unused-certificate.yaml --cache-period 0
-    ...    secret__aws_access_key_id=${AWS_ACCESS_KEY_ID}
-    ...    secret__aws_secret_access_key=${AWS_SECRET_ACCESS_KEY}
+    ...    env=${env}
 
     ${report_data}=     RW.CLI.Run Cli
     ...    cmd=cat ${OUTPUT_DIR}/aws-c7n-acm-health/unused-certificate/resources.json 
@@ -57,15 +56,14 @@ List Unused ACM Certificates in AWS Region `${AWS_REGION}` in AWS Account `${AWS
 
 List Expiring ACM Certificates in AWS Region `${AWS_REGION}` in AWS Account `${AWS_ACCOUNT_ID}`
     [Documentation]  Find Expiring ACM certificates
-    [Tags]    aws    acm    certificate    expiration
+    [Tags]    aws    acm    certificate    expiration    data:config
     CloudCustodian.Core.Generate Policy   
     ...    ${CURDIR}/soon-to-expire-certificates.j2
     ...    days=${CERT_EXPIRY_DAYS}
 
     ${c7n_output}=    RW.CLI.Run Cli
     ...    cmd=custodian run -r ${AWS_REGION} --output-dir ${OUTPUT_DIR}/aws-c7n-acm-health ${CURDIR}/soon-to-expire-certificates.yaml --cache-period 0
-    ...    secret__aws_access_key_id=${AWS_ACCESS_KEY_ID}
-    ...    secret__aws_secret_access_key=${AWS_SECRET_ACCESS_KEY}
+    ...    env=${env}
 
     ${report_data}=     RW.CLI.Run Cli
     ...    cmd=cat ${OUTPUT_DIR}/aws-c7n-acm-health/soon-to-expire-certificates/resources.json 
@@ -104,11 +102,10 @@ List Expiring ACM Certificates in AWS Region `${AWS_REGION}` in AWS Account `${A
 
 List Expired ACM Certificates in AWS Region `${AWS_REGION}` in AWS Account `${AWS_ACCOUNT_ID}`
     [Documentation]  Find expired ACM certificates
-    [Tags]    aws    acm    certificate    expiration
+    [Tags]    aws    acm    certificate    expiration    data:config
     ${c7n_output}=    RW.CLI.Run Cli
     ...    cmd=custodian run -r ${AWS_REGION} --output-dir ${OUTPUT_DIR}/aws-c7n-acm-health ${CURDIR}/expired-certificate.yaml --cache-period 0
-    ...    secret__aws_access_key_id=${AWS_ACCESS_KEY_ID}
-    ...    secret__aws_secret_access_key=${AWS_SECRET_ACCESS_KEY}
+    ...    env=${env}
 
     ${report_data}=     RW.CLI.Run Cli
     ...    cmd=cat ${OUTPUT_DIR}/aws-c7n-acm-health/expired-certificate/resources.json 
@@ -146,11 +143,10 @@ List Expired ACM Certificates in AWS Region `${AWS_REGION}` in AWS Account `${AW
 
 List Failed Status ACM Certificates in AWS Region `${AWS_REGION}` in AWS Account `${AWS_ACCOUNT_ID}`
     [Documentation]  Find failed status ACM certificates
-    [Tags]    aws    acm    certificate    status
+    [Tags]    aws    acm    certificate    status    data:config
     ${c7n_output}=    RW.CLI.Run Cli
     ...    cmd=custodian run -r ${AWS_REGION} --output-dir ${OUTPUT_DIR}/aws-c7n-acm-health ${CURDIR}/failed-status-certificate.yaml --cache-period 0
-    ...    secret__aws_access_key_id=${AWS_ACCESS_KEY_ID}
-    ...    secret__aws_secret_access_key=${AWS_SECRET_ACCESS_KEY}
+    ...    env=${env}
 
     ${report_data}=     RW.CLI.Run Cli
     ...    cmd=cat ${OUTPUT_DIR}/aws-c7n-acm-health/failed-status-certificate/resources.json 
@@ -189,11 +185,10 @@ List Failed Status ACM Certificates in AWS Region `${AWS_REGION}` in AWS Account
 
 List Pending Validation ACM Certificates in AWS Region `${AWS_REGION}` in AWS Account `${AWS_ACCOUNT_ID}`
     [Documentation]  Find pending validation ACM certificates
-    [Tags]    aws    acm    certificate    status
+    [Tags]    aws    acm    certificate    status    data:config
     ${c7n_output}=    RW.CLI.Run Cli
     ...    cmd=custodian run -r ${AWS_REGION} --output-dir ${OUTPUT_DIR}/aws-c7n-acm-health ${CURDIR}/pending-validation-certificate.yaml --cache-period 0
-    ...    secret__aws_access_key_id=${AWS_ACCESS_KEY_ID}
-    ...    secret__aws_secret_access_key=${AWS_SECRET_ACCESS_KEY}
+    ...    env=${env}
 
     ${report_data}=     RW.CLI.Run Cli
     ...    cmd=cat ${OUTPUT_DIR}/aws-c7n-acm-health/pending-validation-certificate/resources.json 
@@ -241,13 +236,9 @@ Suite Initialization
     ...    type=string
     ...    description=AWS Account ID
     ...    pattern=\w*
-    ${AWS_ACCESS_KEY_ID}=    RW.Core.Import Secret   AWS_ACCESS_KEY_ID
+    ${aws_credentials}=    RW.Core.Import Secret    aws_credentials
     ...    type=string
-    ...    description=AWS Access Key ID
-    ...    pattern=\w*
-    ${AWS_SECRET_ACCESS_KEY}=    RW.Core.Import Secret   AWS_SECRET_ACCESS_KEY
-    ...    type=string
-    ...    description=AWS Access Key Secret
+    ...    description=AWS credentials from the workspace (from aws-auth block; e.g. aws:access_key@cli, aws:irsa@cli).
     ...    pattern=\w*
     ${CERT_EXPIRY_DAYS}=    RW.Core.Import User Variable    CERT_EXPIRY_DAYS
     ...    type=string
@@ -259,5 +250,9 @@ Suite Initialization
     Set Suite Variable    ${AWS_REGION}    ${AWS_REGION}
     Set Suite Variable    ${CERT_EXPIRY_DAYS}    ${CERT_EXPIRY_DAYS}
     Set Suite Variable    ${AWS_ACCOUNT_ID}    ${AWS_ACCOUNT_ID}
-    Set Suite Variable    ${AWS_ACCESS_KEY_ID}    ${AWS_ACCESS_KEY_ID}
-    Set Suite Variable    ${AWS_SECRET_ACCESS_KEY}    ${AWS_SECRET_ACCESS_KEY}
+    Set Suite Variable    ${aws_credentials}    ${aws_credentials}
+    # AWS credentials are provided by the platform from the aws-auth block (runwhen-local);
+    # the runtime uses aws_utils to set up the auth environment (IRSA, access key, assume role, etc.).
+    Set Suite Variable
+    ...    &{env}
+    ...    AWS_REGION=${AWS_REGION}

--- a/codebundles/aws-c7n-acm-health/sli.robot
+++ b/codebundles/aws-c7n-acm-health/sli.robot
@@ -14,11 +14,10 @@ Suite Setup    Suite Initialization
 *** Tasks ***
 Check for unused ACM certificates in AWS Region `${AWS_REGION}` in AWS account `${AWS_ACCOUNT_ID}`
     [Documentation]  Find unused ACM certificates
-    [Tags]    aws    acm    certificate    security 
+    [Tags]    aws    acm    certificate    security    data:config
     ${c7n_output}=    RW.CLI.Run Cli
     ...    cmd=custodian run -r ${AWS_REGION} --output-dir ${OUTPUT_DIR}/aws-c7n-acm-health ${CURDIR}/unused-certificate.yaml --cache-period 0
-    ...    secret__aws_access_key_id=${AWS_ACCESS_KEY_ID}
-    ...    secret__aws_secret_access_key=${AWS_SECRET_ACCESS_KEY}
+    ...    env=${env}
     ${count}=     RW.CLI.Run Cli
     ...    cmd=cat ${OUTPUT_DIR}/aws-c7n-acm-health/unused-certificate/metadata.json | jq '.metrics[] | select(.MetricName == "ResourceCount") | .Value';
     ${unused_certificate_score}=    Evaluate    1 if int(${count.stdout}) <= int(${MAX_UNUSED_CERTIFICATES}) else 0
@@ -26,14 +25,13 @@ Check for unused ACM certificates in AWS Region `${AWS_REGION}` in AWS account `
 
 Check for Expiring ACM certificates in AWS Region `${AWS_REGION}` in AWS account `${AWS_ACCOUNT_ID}`
     [Documentation]  Find Expiring ACM certificates
-    [Tags]    aws    acm    certificate    expiration 
+    [Tags]    aws    acm    certificate    expiration    data:config
     CloudCustodian.Core.Generate Policy   
     ...    ${CURDIR}/soon-to-expire-certificates.j2
     ...    days=${CERT_EXPIRY_DAYS}
     ${c7n_output}=    RW.CLI.Run Cli
     ...    cmd=custodian run -r ${AWS_REGION} --output-dir ${OUTPUT_DIR}/aws-c7n-acm-health ${CURDIR}/soon-to-expire-certificates.yaml --cache-period 0
-    ...    secret__aws_access_key_id=${AWS_ACCESS_KEY_ID}
-    ...    secret__aws_secret_access_key=${AWS_SECRET_ACCESS_KEY}
+    ...    env=${env}
     ${count}=     RW.CLI.Run Cli
     ...    cmd=cat ${OUTPUT_DIR}/aws-c7n-acm-health/soon-to-expire-certificates/metadata.json | jq '.metrics[] | select(.MetricName == "ResourceCount") | .Value';
     ${expiring_certificate_score}=    Evaluate    1 if int(${count.stdout}) <= int(${MAX_EXPIRING_CERTIFICATES}) else 0
@@ -41,11 +39,10 @@ Check for Expiring ACM certificates in AWS Region `${AWS_REGION}` in AWS account
 
 Check for expired ACM certificates in AWS Region `${AWS_REGION}` in AWS account `${AWS_ACCOUNT_ID}`
     [Documentation]  Find expired ACM certificates
-    [Tags]    aws    acm    certificate    expiration
+    [Tags]    aws    acm    certificate    expiration    data:config
     ${c7n_output}=    RW.CLI.Run Cli
     ...    cmd=custodian run -r ${AWS_REGION} --output-dir ${OUTPUT_DIR}/aws-c7n-acm-health ${CURDIR}/expired-certificate.yaml --cache-period 0
-    ...    secret__aws_access_key_id=${AWS_ACCESS_KEY_ID}
-    ...    secret__aws_secret_access_key=${AWS_SECRET_ACCESS_KEY}
+    ...    env=${env}
     ${count}=     RW.CLI.Run Cli
     ...    cmd=cat ${OUTPUT_DIR}/aws-c7n-acm-health/expired-certificate/metadata.json | jq '.metrics[] | select(.MetricName == "ResourceCount") | .Value';
     ${expired_certificate_score}=    Evaluate    1 if int(${count.stdout}) <= int(${MAX_EXPIRED_CERTIFICATES}) else 0
@@ -53,11 +50,10 @@ Check for expired ACM certificates in AWS Region `${AWS_REGION}` in AWS account 
 
 Check for Failed Status ACM Certificates in AWS Region `${AWS_REGION}` in AWS Account `${AWS_ACCOUNT_ID}`
     [Documentation]  Find failed status ACM certificates
-    [Tags]    aws    acm    certificate    status
+    [Tags]    aws    acm    certificate    status    data:config
     ${c7n_output}=    RW.CLI.Run Cli
     ...    cmd=custodian run -r ${AWS_REGION} --output-dir ${OUTPUT_DIR}/aws-c7n-acm-health ${CURDIR}/failed-status-certificate.yaml --cache-period 0
-    ...    secret__aws_access_key_id=${AWS_ACCESS_KEY_ID}
-    ...    secret__aws_secret_access_key=${AWS_SECRET_ACCESS_KEY}
+    ...    env=${env}
     ${count}=     RW.CLI.Run Cli
     ...    cmd=cat ${OUTPUT_DIR}/aws-c7n-acm-health/failed-status-certificate/metadata.json | jq '.metrics[] | select(.MetricName == "ResourceCount") | .Value';
     ${failed_certificate_score}=    Evaluate    1 if int(${count.stdout}) <= int(${MAX_FAILED_CERTIFICATES}) else 0
@@ -65,11 +61,10 @@ Check for Failed Status ACM Certificates in AWS Region `${AWS_REGION}` in AWS Ac
 
 Check for Pending Validation ACM Certificates in AWS Region `${AWS_REGION}` in AWS Account `${AWS_ACCOUNT_ID}`
     [Documentation]  Find pending validation ACM certificates
-    [Tags]    aws    acm    certificate    validation
+    [Tags]    aws    acm    certificate    validation    data:config
     ${c7n_output}=    RW.CLI.Run Cli
     ...    cmd=custodian run -r ${AWS_REGION} --output-dir ${OUTPUT_DIR}/aws-c7n-acm-health ${CURDIR}/pending-validation-certificate.yaml --cache-period 0
-    ...    secret__aws_access_key_id=${AWS_ACCESS_KEY_ID}
-    ...    secret__aws_secret_access_key=${AWS_SECRET_ACCESS_KEY}
+    ...    env=${env}
     ${count}=     RW.CLI.Run Cli
     ...    cmd=cat ${OUTPUT_DIR}/aws-c7n-acm-health/pending-validation-certificate/metadata.json | jq '.metrics[] | select(.MetricName == "ResourceCount") | .Value';
     ${pending_validation_score}=    Evaluate    1 if int(${count.stdout}) <= int(${MAX_PENDING_VALIDATION_CERTIFICATES}) else 0
@@ -90,13 +85,9 @@ Suite Initialization
     ...    type=string
     ...    description=AWS Account ID
     ...    pattern=\w*
-    ${AWS_ACCESS_KEY_ID}=    RW.Core.Import Secret   AWS_ACCESS_KEY_ID
+    ${aws_credentials}=    RW.Core.Import Secret    aws_credentials
     ...    type=string
-    ...    description=AWS Access Key ID
-    ...    pattern=\w*
-    ${AWS_SECRET_ACCESS_KEY}=    RW.Core.Import Secret   AWS_SECRET_ACCESS_KEY
-    ...    type=string
-    ...    description=AWS Access Key Secret
+    ...    description=AWS credentials from the workspace (from aws-auth block; e.g. aws:access_key@cli, aws:irsa@cli).
     ...    pattern=\w*
     ${MAX_UNUSED_CERTIFICATES}=    RW.Core.Import User Variable    MAX_UNUSED_CERTIFICATES
     ...    type=string
@@ -143,5 +134,9 @@ Suite Initialization
     Set Suite Variable    ${MAX_EXPIRING_CERTIFICATES}    ${MAX_EXPIRING_CERTIFICATES}
     Set Suite Variable    ${MAX_EXPIRED_CERTIFICATES}    ${MAX_EXPIRED_CERTIFICATES}
     Set Suite Variable    ${MAX_PENDING_VALIDATION_CERTIFICATES}    ${MAX_PENDING_VALIDATION_CERTIFICATES}
-    Set Suite Variable    ${AWS_ACCESS_KEY_ID}    ${AWS_ACCESS_KEY_ID}
-    Set Suite Variable    ${AWS_SECRET_ACCESS_KEY}    ${AWS_SECRET_ACCESS_KEY}
+    Set Suite Variable    ${aws_credentials}    ${aws_credentials}
+    # AWS credentials are provided by the platform from the aws-auth block (runwhen-local);
+    # the runtime uses aws_utils to set up the auth environment (IRSA, access key, assume role, etc.).
+    Set Suite Variable
+    ...    &{env}
+    ...    AWS_REGION=${AWS_REGION}

--- a/codebundles/aws-c7n-ebs-health/.runwhen/templates/aws-c7n-ebs-health-sli.yaml
+++ b/codebundles/aws-c7n-ebs-health/.runwhen/templates/aws-c7n-ebs-health-sli.yaml
@@ -32,10 +32,7 @@ spec:
     - name: AWS_ACCOUNT_ID
       value: "{{match_resource.resource.account_id}}"
   secretsProvided:
-    - name: AWS_ACCESS_KEY_ID
-      workspaceKey: {{custom.aws_access_key_id}}
-    - name: AWS_SECRET_ACCESS_KEY
-      workspaceKey: {{custom.aws_secret_access_key}}
+    {% include "aws-auth.yaml" ignore missing %}
   alerts:
     warning:
       operator: <

--- a/codebundles/aws-c7n-ebs-health/.runwhen/templates/aws-c7n-ebs-health-taskset.yaml
+++ b/codebundles/aws-c7n-ebs-health/.runwhen/templates/aws-c7n-ebs-health-taskset.yaml
@@ -27,7 +27,4 @@ spec:
     - name: AWS_ACCOUNT_ID
       value: "{{match_resource.resource.account_id}}"
   secretsProvided:
-    - name: AWS_ACCESS_KEY_ID
-      workspaceKey: {{custom.aws_access_key_id}}
-    - name: AWS_SECRET_ACCESS_KEY
-      workspaceKey: {{custom.aws_secret_access_key}}
+    {% include "aws-auth.yaml" ignore missing %}

--- a/codebundles/aws-c7n-ebs-health/runbook.robot
+++ b/codebundles/aws-c7n-ebs-health/runbook.robot
@@ -16,11 +16,10 @@ Suite Setup    Suite Initialization
 *** Tasks ***
 List Unattached EBS Volumes in AWS Region `${AWS_REGION}` in AWS account `${AWS_ACCOUNT_ID}` 
     [Documentation]  Check for unattached EBS volumes in the specified region. 
-    [Tags]    ebs    storage    aws    volume    unattached
+    [Tags]    ebs    storage    aws    volume    unattached    data:config
     ${c7n_output}=    RW.CLI.Run Cli
     ...    cmd=custodian run -r ${AWS_REGION} --output-dir ${OUTPUT_DIR}/aws-c7n-ebs-health ${CURDIR}/unattached-ebs-volumes.yaml --cache-period 0
-    ...    secret__aws_account_id=${AWS_ACCESS_KEY_ID}
-    ...    secret__aws_secret_access_key=${AWS_SECRET_ACCESS_KEY}
+    ...    env=${env}
     ${report_data}=     RW.CLI.Run Cli
     ...    cmd=cat ${OUTPUT_DIR}/aws-c7n-ebs-health/unattached-ebs-volumes/resources.json 
     RW.Core.Add Pre To Report    ${c7n_output.stdout}     # Data needs to be parsed to be usable in the report.
@@ -54,11 +53,10 @@ List Unattached EBS Volumes in AWS Region `${AWS_REGION}` in AWS account `${AWS_
 
 List Unencrypted EBS Volumes in AWS Region `${AWS_REGION}` in AWS account `${AWS_ACCOUNT_ID}`
     [Documentation]  Check for Unencrypted EBS Volumes in the specified region. 
-    [Tags]    ebs    storage    aws    volume    encryption
+    [Tags]    ebs    storage    aws    volume    encryption    data:config
     ${c7n_output}=    RW.CLI.Run Cli
     ...    cmd=custodian run -r ${AWS_REGION} --output-dir ${OUTPUT_DIR}/aws-c7n-ebs-health ${CURDIR}/unencrypted-ebs-volumes.yaml --cache-period 0
-    ...    secret__aws_account_id=${AWS_ACCESS_KEY_ID}
-    ...    secret__aws_secret_access_key=${AWS_SECRET_ACCESS_KEY}
+    ...    env=${env}
     ${report_data}=     RW.CLI.Run Cli
     ...    cmd=cat ${OUTPUT_DIR}/aws-c7n-ebs-health/unencrypted-ebs-volumes/resources.json 
     RW.Core.Add Pre To Report    ${c7n_output.stdout} 
@@ -92,11 +90,10 @@ List Unencrypted EBS Volumes in AWS Region `${AWS_REGION}` in AWS account `${AWS
 
 List Unused EBS Snapshots in AWS Region `${AWS_REGION}` in AWS account `${AWS_ACCOUNT_ID}`
     [Documentation]  Check for Unused EBS Snapshots in the specified region. 
-    [Tags]    ebs    storage    aws    volume    unused
+    [Tags]    ebs    storage    aws    volume    unused    data:config
     ${c7n_output}=    RW.CLI.Run Cli
     ...    cmd=custodian run -r ${AWS_REGION} --output-dir ${OUTPUT_DIR}/aws-c7n-ebs-health ${CURDIR}/unused-ebs-snapshots.yaml --cache-period 0
-    ...    secret__aws_account_id=${AWS_ACCESS_KEY_ID}
-    ...    secret__aws_secret_access_key=${AWS_SECRET_ACCESS_KEY}
+    ...    env=${env}
     ${report_data}=     RW.CLI.Run Cli
     ...    cmd=cat ${OUTPUT_DIR}/aws-c7n-ebs-health/unused-ebs-snapshots/resources.json 
     RW.Core.Add Pre To Report    ${c7n_output.stdout}  
@@ -137,13 +134,9 @@ Suite Initialization
     ...    type=string
     ...    description=AWS Account ID
     ...    pattern=\w*
-    ${AWS_ACCESS_KEY_ID}=    RW.Core.Import Secret   AWS_ACCESS_KEY_ID
+    ${aws_credentials}=    RW.Core.Import Secret    aws_credentials
     ...    type=string
-    ...    description=AWS Access Key ID
-    ...    pattern=\w*
-    ${AWS_SECRET_ACCESS_KEY}=    RW.Core.Import Secret   AWS_SECRET_ACCESS_KEY
-    ...    type=string
-    ...    description=AWS Access Key Secret
+    ...    description=AWS credentials from the workspace (from aws-auth block; e.g. aws:access_key@cli, aws:irsa@cli).
     ...    pattern=\w*
     ${aws_account_name_query}=       RW.CLI.Run Cli    
     ...    cmd=aws organizations describe-account --account-id $(aws sts get-caller-identity --query 'Account' --output text) --query "Account.Name" --output text | tr -d '\n'
@@ -151,5 +144,9 @@ Suite Initialization
     Set Suite Variable    ${AWS_ACCOUNT_NAME}    ${aws_account_name_query.stdout}
     Set Suite Variable    ${AWS_REGION}    ${AWS_REGION}
     Set Suite Variable    ${AWS_ACCOUNT_ID}    ${AWS_ACCOUNT_ID}
-    Set Suite Variable    ${AWS_ACCESS_KEY_ID}    ${AWS_ACCESS_KEY_ID}
-    Set Suite Variable    ${AWS_SECRET_ACCESS_KEY}    ${AWS_SECRET_ACCESS_KEY}
+    Set Suite Variable    ${aws_credentials}    ${aws_credentials}
+    # AWS credentials are provided by the platform from the aws-auth block (runwhen-local);
+    # the runtime uses aws_utils to set up the auth environment (IRSA, access key, assume role, etc.).
+    Set Suite Variable
+    ...    &{env}
+    ...    AWS_REGION=${AWS_REGION}

--- a/codebundles/aws-c7n-ebs-health/sli.robot
+++ b/codebundles/aws-c7n-ebs-health/sli.robot
@@ -13,11 +13,10 @@ Suite Setup    Suite Initialization
 *** Tasks ***
 Check Unattached EBS Volumes in `${AWS_REGION}`
     [Documentation]  Check for unattached EBS volumes in the specified region. 
-    [Tags]    ebs    storage    aws    volume
+    [Tags]    ebs    storage    aws    volume    data:config
     ${c7n_output}=    RW.CLI.Run Cli
     ...    cmd=custodian run -r ${AWS_REGION} --output-dir ${OUTPUT_DIR}/aws-c7n-ebs-health ${CURDIR}/unattached-ebs-volumes.yaml --cache-period 0
-    ...    secret__aws_access_key_id=${AWS_ACCESS_KEY_ID}
-    ...    secret__aws_secret_access_key=${AWS_SECRET_ACCESS_KEY}
+    ...    env=${env}
     ${count}=     RW.CLI.Run Cli
     ...    cmd=cat ${OUTPUT_DIR}/aws-c7n-ebs-health/unattached-ebs-volumes/metadata.json | jq '.metrics[] | select(.MetricName == "ResourceCount") | .Value'
     ${unattached_ebs_event_score}=    Evaluate    1 if int(${count.stdout}) <= int(${EVENT_THRESHOLD}) else 0
@@ -25,11 +24,10 @@ Check Unattached EBS Volumes in `${AWS_REGION}`
 
 Check Unencrypted EBS Volumes in `${AWS_REGION}`
     [Documentation]  Check for unencrypted EBS volumes and report any found that do not meet encryption requirements.
-    [Tags]    ebs    storage    aws    security    volume
+    [Tags]    ebs    storage    aws    security    volume    data:config
     ${c7n_output}=    RW.CLI.Run Cli
     ...    cmd=custodian run -r ${AWS_REGION} --output-dir ${OUTPUT_DIR}/aws-c7n-ebs-health ${CURDIR}/unencrypted-ebs-volumes.yaml --cache-period 0
-    ...    secret__aws_access_key_id=${AWS_ACCESS_KEY_ID}
-    ...    secret__aws_secret_access_key=${AWS_SECRET_ACCESS_KEY}
+    ...    env=${env}
     ${count}=     RW.CLI.Run Cli
     ...    cmd=cat ${OUTPUT_DIR}/aws-c7n-ebs-health/unencrypted-ebs-volumes/metadata.json | jq '.metrics[] | select(.MetricName == "ResourceCount") | .Value'
     ${unencrypted_ebs_event_score}=    Evaluate    1 if int(${count.stdout}) <= int(${SECURITY_EVENT_THRESHOLD}) else 0
@@ -38,11 +36,10 @@ Check Unencrypted EBS Volumes in `${AWS_REGION}`
 
 Check Unused EBS Snapshots in `${AWS_REGION}`
     [Documentation]  Check for unused EBS snapshots. 
-    [Tags]    ebs    storage    aws    snapshots    volume
+    [Tags]    ebs    storage    aws    snapshots    volume    data:config
     ${c7n_output}=    RW.CLI.Run Cli
     ...    cmd=custodian run -r ${AWS_REGION} --output-dir ${OUTPUT_DIR}/aws-c7n-ebs-health ${CURDIR}/unused-ebs-snapshots.yaml --cache-period 0
-    ...    secret__aws_access_key_id=${AWS_ACCESS_KEY_ID}
-    ...    secret__aws_secret_access_key=${AWS_SECRET_ACCESS_KEY}
+    ...    env=${env}
     ${count}=     RW.CLI.Run Cli
     ...    cmd=cat ${OUTPUT_DIR}/aws-c7n-ebs-health/unused-ebs-snapshots/metadata.json | jq '.metrics[] | select(.MetricName == "ResourceCount") | .Value'
     ${unsued_ebs_snapshot_event_score}=    Evaluate    1 if int(${count.stdout}) <= int(${EVENT_THRESHOLD}) else 0
@@ -64,13 +61,9 @@ Suite Initialization
     ...    type=string
     ...    description=AWS Account ID
     ...    pattern=\w*
-    ${AWS_ACCESS_KEY_ID}=    RW.Core.Import Secret   AWS_ACCESS_KEY_ID
+    ${aws_credentials}=    RW.Core.Import Secret    aws_credentials
     ...    type=string
-    ...    description=AWS Access Key ID
-    ...    pattern=\w*
-    ${AWS_SECRET_ACCESS_KEY}=    RW.Core.Import Secret   AWS_SECRET_ACCESS_KEY
-    ...    type=string
-    ...    description=AWS Access Key Secret
+    ...    description=AWS credentials from the workspace (from aws-auth block; e.g. aws:access_key@cli, aws:irsa@cli).
     ...    pattern=\w*
     ${EVENT_THRESHOLD}=    RW.Core.Import User Variable    EVENT_THRESHOLD
     ...    type=string
@@ -89,5 +82,9 @@ Suite Initialization
     Set Suite Variable    ${AWS_ACCOUNT_ID}    ${AWS_ACCOUNT_ID}
     Set Suite Variable    ${EVENT_THRESHOLD}    ${EVENT_THRESHOLD}
     Set Suite Variable    ${SECURITY_EVENT_THRESHOLD}    ${SECURITY_EVENT_THRESHOLD}
-    Set Suite Variable    ${AWS_ACCESS_KEY_ID}    ${AWS_ACCESS_KEY_ID}
-    Set Suite Variable    ${AWS_SECRET_ACCESS_KEY}    ${AWS_SECRET_ACCESS_KEY}
+    Set Suite Variable    ${aws_credentials}    ${aws_credentials}
+    # AWS credentials are provided by the platform from the aws-auth block (runwhen-local);
+    # the runtime uses aws_utils to set up the auth environment (IRSA, access key, assume role, etc.).
+    Set Suite Variable
+    ...    &{env}
+    ...    AWS_REGION=${AWS_REGION}

--- a/codebundles/aws-c7n-ec2-health/.runwhen/templates/aws-c7n-ec2-health-sli.yaml
+++ b/codebundles/aws-c7n-ec2-health/.runwhen/templates/aws-c7n-ec2-health-sli.yaml
@@ -40,10 +40,7 @@ spec:
     - name: MAX_ALLOWED_STALE_INSTANCES
       value: '0'
   secretsProvided:
-    - name: AWS_ACCESS_KEY_ID
-      workspaceKey: {{custom.aws_access_key_id}}
-    - name: AWS_SECRET_ACCESS_KEY
-      workspaceKey: {{custom.aws_secret_access_key}}
+    {% include "aws-auth.yaml" ignore missing %}
   alerts:
     warning:
       operator: <

--- a/codebundles/aws-c7n-ec2-health/.runwhen/templates/aws-c7n-ec2-health-taskset.yaml
+++ b/codebundles/aws-c7n-ec2-health/.runwhen/templates/aws-c7n-ec2-health-taskset.yaml
@@ -35,7 +35,4 @@ spec:
     - name: MAX_ALLOWED_STALE_INSTANCES
       value: '0'
   secretsProvided:
-    - name: AWS_ACCESS_KEY_ID
-      workspaceKey: {{custom.aws_access_key_id}}
-    - name: AWS_SECRET_ACCESS_KEY
-      workspaceKey: {{custom.aws_secret_access_key}}
+    {% include "aws-auth.yaml" ignore missing %}

--- a/codebundles/aws-c7n-ec2-health/runbook.robot
+++ b/codebundles/aws-c7n-ec2-health/runbook.robot
@@ -15,7 +15,7 @@ Suite Setup    Suite Initialization
 *** Tasks ***
 List stale AWS EC2 instances in AWS Region `${AWS_REGION}` in AWS account `${AWS_ACCOUNT_ID}` 
     [Documentation]  List stale EC2 instances in AWS Region. 
-    [Tags]    ec2    instance    aws    compute    stale    
+    [Tags]    ec2    instance    aws    compute    stale    data:config
 
     # Generate the Cloud Custodian policy
     ${result}=    CloudCustodian.Core.Generate Policy   
@@ -26,8 +26,7 @@ List stale AWS EC2 instances in AWS Region `${AWS_REGION}` in AWS account `${AWS
     # Run the Cloud Custodian policy
     ${c7n_output}=    RW.CLI.Run Cli
     ...    cmd=custodian run -r ${AWS_REGION} --output-dir ${OUTPUT_DIR}/aws-c7n-ec2-health ${CURDIR}/stale-ec2-instances.yaml --cache-period 0
-    ...    secret__aws_access_key_id=${AWS_ACCESS_KEY_ID}
-    ...    secret__aws_secret_access_key=${AWS_SECRET_ACCESS_KEY}
+    ...    env=${env}
 
     # Read the generated report data
     ${report_data}=     RW.CLI.Run Cli
@@ -68,19 +67,18 @@ List stale AWS EC2 instances in AWS Region `${AWS_REGION}` in AWS account `${AWS
 
 List stopped AWS EC2 instances in AWS Region `${AWS_REGION}` in AWS account `${AWS_ACCOUNT_ID}` 
     [Documentation]  List stopped EC2 instances in AWS Region. 
-    [Tags]    ec2    instance    aws    compute
-
+    [Tags]    ec2    instance    aws    compute    data:config
+    
     # Generate the Cloud Custodian policy
     ${result}=    CloudCustodian.Core.Generate Policy   
-    ...    ${CURDIR}/stopped-ec2-instances.j2    
+    ...    ${CURDIR}/stopped-ec2-instances.j2
     ...    days=${AWS_EC2_AGE}  
     ...    tags=${AWS_EC2_TAGS}
 
     # Run the Cloud Custodian policy
     ${c7n_output}=    RW.CLI.Run Cli
     ...    cmd=custodian run -r ${AWS_REGION} --output-dir ${OUTPUT_DIR}/aws-c7n-ec2-health ${CURDIR}/stopped-ec2-instances.yaml --cache-period 0
-    ...    secret__aws_access_key_id=${AWS_ACCESS_KEY_ID}
-    ...    secret__aws_secret_access_key=${AWS_SECRET_ACCESS_KEY}
+    ...    env=${env}
 
     ${parsed_results}=    CloudCustodian.Core.Parse Custodian Results
     ...    input_dir=${OUTPUT_DIR}/aws-c7n-ec2-health/stopped-ec2-instances
@@ -122,13 +120,12 @@ List stopped AWS EC2 instances in AWS Region `${AWS_REGION}` in AWS account `${A
 
 List invalid AWS Auto Scaling Groups in AWS Region ${AWS_REGION} in AWS account ${AWS_ACCOUNT_ID}
     [Documentation]  List invalid Auto Scaling Groups
-    [Tags]    asg    aws    compute    asg
+    [Tags]    asg    aws    compute    asg    data:config
 
     # Run the Cloud Custodian policy
     ${c7n_output}=    RW.CLI.Run Cli
     ...    cmd=custodian run -r ${AWS_REGION} --output-dir ${OUTPUT_DIR}/aws-c7n-ec2-health ${CURDIR}/invalid-asg.yaml --cache-period 0
-    ...    secret__aws_access_key_id=${AWS_ACCESS_KEY_ID}
-    ...    secret__aws_secret_access_key=${AWS_SECRET_ACCESS_KEY}
+    ...    env=${env}
 
     # Read the generated report data
     ${report_data}=     RW.CLI.Run Cli
@@ -200,13 +197,9 @@ Suite Initialization
     ...    type=string
     ...    description=AWS Account ID
     ...    pattern=\w*
-    ${AWS_ACCESS_KEY_ID}=    RW.Core.Import Secret   AWS_ACCESS_KEY_ID
+    ${aws_credentials}=    RW.Core.Import Secret    aws_credentials
     ...    type=string
-    ...    description=AWS Access Key ID
-    ...    pattern=\w*
-    ${AWS_SECRET_ACCESS_KEY}=    RW.Core.Import Secret   AWS_SECRET_ACCESS_KEY
-    ...    type=string
-    ...    description=AWS Access Key Secret
+    ...    description=AWS credentials from the workspace (from aws-auth block; e.g. aws:access_key@cli, aws:irsa@cli).
     ...    pattern=\w*
     ${MAX_ALLOWED_STOPPED_INSTANCES}=    RW.Core.Import User Variable    MAX_ALLOWED_STOPPED_INSTANCES
     ...    type=string
@@ -246,5 +239,9 @@ Suite Initialization
     Set Suite Variable    ${MAX_ALLOWED_STOPPED_INSTANCES}    ${MAX_ALLOWED_STOPPED_INSTANCES}
     Set Suite Variable    ${MAX_ALLOWED_STALE_INSTANCES}    ${MAX_ALLOWED_STALE_INSTANCES}
     Set Suite Variable    ${MAX_ALLOWED_INVALID_ASG}    ${MAX_ALLOWED_INVALID_ASG}
-    Set Suite Variable    ${AWS_ACCESS_KEY_ID}    ${AWS_ACCESS_KEY_ID}
-    Set Suite Variable    ${AWS_SECRET_ACCESS_KEY}    ${AWS_SECRET_ACCESS_KEY}
+    Set Suite Variable    ${aws_credentials}    ${aws_credentials}
+    # AWS credentials are provided by the platform from the aws-auth block (runwhen-local);
+    # the runtime uses aws_utils to set up the auth environment (IRSA, access key, assume role, etc.).
+    Set Suite Variable
+    ...    &{env}
+    ...    AWS_REGION=${AWS_REGION}

--- a/codebundles/aws-c7n-ec2-health/sli.robot
+++ b/codebundles/aws-c7n-ec2-health/sli.robot
@@ -15,15 +15,14 @@ Suite Setup    Suite Initialization
 *** Tasks ***
 Check for stale AWS EC2 instances in AWS Region `${AWS_REGION}` in AWS account `${AWS_ACCOUNT_ID}` 
     [Documentation]  Check for stale EC2 instances in AWS Region. 
-    [Tags]    ec2    instance    aws    compute
+    [Tags]    ec2    instance    aws    compute    data:config
     ${result}=    CloudCustodian.Core.Generate Policy   
     ...    ${CURDIR}/stale-ec2-instances.j2    
     ...    days=${AWS_EC2_AGE}        
     ...    tags=${AWS_EC2_TAGS}
     ${c7n_output}=    RW.CLI.Run Cli
     ...    cmd=custodian run -r ${AWS_REGION} --output-dir ${OUTPUT_DIR}/aws-c7n-ec2-health ${CURDIR}/stale-ec2-instances.yaml --cache-period 0
-    ...    secret__aws_access_key_id=${AWS_ACCESS_KEY_ID}
-    ...    secret__aws_secret_access_key=${AWS_SECRET_ACCESS_KEY}
+    ...    env=${env}
     ${count}=     RW.CLI.Run Cli
     ...    cmd=cat ${OUTPUT_DIR}/aws-c7n-ec2-health/stale-ec2-instances/metadata.json | jq '.metrics[] | select(.MetricName == "ResourceCount") | .Value'
     ${stale_ec2_instances_score}=    Evaluate    1 if int(${count.stdout}) <= int(${MAX_ALLOWED_STALE_INSTANCES}) else 0
@@ -31,15 +30,14 @@ Check for stale AWS EC2 instances in AWS Region `${AWS_REGION}` in AWS account `
 
 Check for stopped AWS EC2 instances in AWS Region `${AWS_REGION}` in AWS account `${AWS_ACCOUNT_ID}` 
     [Documentation]  Check for stopped EC2 instances in AWS Region. 
-    [Tags]    ec2    instance    aws    compute
+    [Tags]    ec2    instance    aws    compute    data:config
     ${result}=    CloudCustodian.Core.Generate Policy   
     ...    ${CURDIR}/stopped-ec2-instances.j2    
     ...    days=${AWS_EC2_AGE}        
     ...    tags=${AWS_EC2_TAGS}
     ${c7n_output}=    RW.CLI.Run Cli
     ...    cmd=custodian run -r ${AWS_REGION} --output-dir ${OUTPUT_DIR}/aws-c7n-ec2-health ${CURDIR}/stopped-ec2-instances.yaml --cache-period 0
-    ...    secret__aws_access_key_id=${AWS_ACCESS_KEY_ID}
-    ...    secret__aws_secret_access_key=${AWS_SECRET_ACCESS_KEY}
+    ...    env=${env}
     ${count}=     RW.CLI.Run Cli
     ...    cmd=cat ${OUTPUT_DIR}/aws-c7n-ec2-health/stopped-ec2-instances/metadata.json | jq '.metrics[] | select(.MetricName == "ResourceCount") | .Value'
     ${stopped_ec2_instances_score}=    Evaluate    1 if int(${count.stdout}) <= int(${MAX_ALLOWED_STOPPED_INSTANCES}) else 0
@@ -47,11 +45,10 @@ Check for stopped AWS EC2 instances in AWS Region `${AWS_REGION}` in AWS account
 
 Check for invalid AWS Auto Scaling Groups in AWS Region `${AWS_REGION}` in AWS account `${AWS_ACCOUNT_ID}`
     [Documentation]  Check for invalid Auto Scaling Groups.
-    [Tags]    asg    aws    compute
+    [Tags]    asg    aws    compute    data:config
     ${c7n_output}=    RW.CLI.Run Cli
     ...    cmd=custodian run -r ${AWS_REGION} --output-dir ${OUTPUT_DIR}/aws-c7n-ec2-health ${CURDIR}/invalid-asg.yaml --cache-period 0
-    ...    secret__aws_access_key_id=${AWS_ACCESS_KEY_ID}
-    ...    secret__aws_secret_access_key=${AWS_SECRET_ACCESS_KEY}
+    ...    env=${env}
     ${count}=     RW.CLI.Run Cli
     ...    cmd=cat ${OUTPUT_DIR}/aws-c7n-ec2-health/invalid-asg/metadata.json | jq '.metrics[] | select(.MetricName == "ResourceCount") | .Value'
     ${invalid_asg_score}=    Evaluate    1 if int(${count.stdout}) <= int(${MAX_ALLOWED_INVALID_ASG}) else 0
@@ -72,13 +69,9 @@ Suite Initialization
     ...    type=string
     ...    description=AWS Account ID
     ...    pattern=\w*
-    ${AWS_ACCESS_KEY_ID}=    RW.Core.Import Secret   AWS_ACCESS_KEY_ID
+    ${aws_credentials}=    RW.Core.Import Secret    aws_credentials
     ...    type=string
-    ...    description=AWS Access Key ID
-    ...    pattern=\w*
-    ${AWS_SECRET_ACCESS_KEY}=    RW.Core.Import Secret   AWS_SECRET_ACCESS_KEY
-    ...    type=string
-    ...    description=AWS Access Key Secret
+    ...    description=AWS credentials from the workspace (from aws-auth block; e.g. aws:access_key@cli, aws:irsa@cli).
     ...    pattern=\w*
     ${MAX_ALLOWED_STOPPED_INSTANCES}=    RW.Core.Import User Variable    MAX_ALLOWED_STOPPED_INSTANCES
     ...    type=string
@@ -118,5 +111,9 @@ Suite Initialization
     Set Suite Variable    ${MAX_ALLOWED_STOPPED_INSTANCES}    ${MAX_ALLOWED_STOPPED_INSTANCES}
     Set Suite Variable    ${MAX_ALLOWED_STALE_INSTANCES}    ${MAX_ALLOWED_STALE_INSTANCES}
     Set Suite Variable    ${MAX_ALLOWED_INVALID_ASG}    ${MAX_ALLOWED_INVALID_ASG}
-    Set Suite Variable    ${AWS_ACCESS_KEY_ID}    ${AWS_ACCESS_KEY_ID}
-    Set Suite Variable    ${AWS_SECRET_ACCESS_KEY}    ${AWS_SECRET_ACCESS_KEY}
+    Set Suite Variable    ${aws_credentials}    ${aws_credentials}
+    # AWS credentials are provided by the platform from the aws-auth block (runwhen-local);
+    # the runtime uses aws_utils to set up the auth environment (IRSA, access key, assume role, etc.).
+    Set Suite Variable
+    ...    &{env}
+    ...    AWS_REGION=${AWS_REGION}

--- a/codebundles/aws-c7n-monitoring-health/.runwhen/templates/aws-c7n-monitoring-health-sli.yaml
+++ b/codebundles/aws-c7n-monitoring-health/.runwhen/templates/aws-c7n-monitoring-health-sli.yaml
@@ -32,10 +32,7 @@ spec:
     - name: AWS_ACCOUNT_ID
       value: "{{match_resource.resource.account_id}}"
   secretsProvided:
-    - name: AWS_ACCESS_KEY_ID
-      workspaceKey: {{custom.aws_access_key_id}}
-    - name: AWS_SECRET_ACCESS_KEY
-      workspaceKey: {{custom.aws_secret_access_key}}
+    {% include "aws-auth.yaml" ignore missing %}
   alerts:
     warning:
       operator: <

--- a/codebundles/aws-c7n-monitoring-health/.runwhen/templates/aws-c7n-monitoring-health-taskset.yaml
+++ b/codebundles/aws-c7n-monitoring-health/.runwhen/templates/aws-c7n-monitoring-health-taskset.yaml
@@ -27,7 +27,4 @@ spec:
     - name: AWS_ACCOUNT_ID
       value: "{{match_resource.resource.account_id}}"
   secretsProvided:
-    - name: AWS_ACCESS_KEY_ID
-      workspaceKey: {{custom.aws_access_key_id}}
-    - name: AWS_SECRET_ACCESS_KEY
-      workspaceKey: {{custom.aws_secret_access_key}} 
+    {% include "aws-auth.yaml" ignore missing %}

--- a/codebundles/aws-c7n-monitoring-health/runbook.robot
+++ b/codebundles/aws-c7n-monitoring-health/runbook.robot
@@ -14,11 +14,10 @@ Suite Setup    Suite Initialization
 *** Tasks ***
 List CloudWatch Log Groups Without Retention Period in AWS Region `${AWS_REGION}` in AWS Account `${AWS_ACCOUNT_ID}`
     [Documentation]  List CloudWatch Log Groups Without Retention Period
-    [Tags]    aws    cloudwatch    logs
+    [Tags]    aws    cloudwatch    logs    data:config
     ${c7n_output}=    RW.CLI.Run Cli
     ...    cmd=custodian run -r ${AWS_REGION} --output-dir ${OUTPUT_DIR}/aws-c7n-monitoring-health ${CURDIR}/log-groups-no-retention.yaml --cache-period 0
-    ...    secret__aws_access_key_id=${AWS_ACCESS_KEY_ID}
-    ...    secret__aws_secret_access_key=${AWS_SECRET_ACCESS_KEY}
+    ...    env=${env}
 
     ${report_data}=     RW.CLI.Run Cli
     ...    cmd=cat ${OUTPUT_DIR}/aws-c7n-monitoring-health/log-groups-no-retention/resources.json 
@@ -54,11 +53,10 @@ List CloudWatch Log Groups Without Retention Period in AWS Region `${AWS_REGION}
 
 Check CloudTrail Configuration in AWS Region `${AWS_REGION}` in AWS Account `${AWS_ACCOUNT_ID}`
     [Documentation]    Check if CloudTrail exists and is configured for multi-region
-    [Tags]    aws    cloudtrail
+    [Tags]    aws    cloudtrail    data:config
     ${c7n_output}=    RW.CLI.Run Cli
     ...    cmd=custodian run -r ${AWS_REGION} --output-dir ${OUTPUT_DIR}/aws-c7n-monitoring-health ${CURDIR}/list-trail.yaml --cache-period 0
-    ...    secret__aws_access_key_id=${AWS_ACCESS_KEY_ID}
-    ...    secret__aws_secret_access_key=${AWS_SECRET_ACCESS_KEY}
+    ...    env=${env}
 
     ${report_data}=     RW.CLI.Run Cli
     ...    cmd=cat ${OUTPUT_DIR}/aws-c7n-monitoring-health/list-cloudtrail-trails/resources.json
@@ -86,8 +84,7 @@ Check CloudTrail Configuration in AWS Region `${AWS_REGION}` in AWS Account `${A
         # Check for multi-region trails
         ${c7n_output}=    RW.CLI.Run Cli
         ...    cmd=custodian run -r ${AWS_REGION} --output-dir ${OUTPUT_DIR}/aws-c7n-monitoring-health ${CURDIR}/trail-no-multi-region.yaml --cache-period 0
-        ...    secret__aws_access_key_id=${AWS_ACCESS_KEY_ID}
-        ...    secret__aws_secret_access_key=${AWS_SECRET_ACCESS_KEY}
+        ...    env=${env}
 
         ${report_data}=     RW.CLI.Run Cli
         ...    cmd=cat ${OUTPUT_DIR}/aws-c7n-monitoring-health/trail-no-multi-region/resources.json
@@ -120,11 +117,10 @@ Check CloudTrail Configuration in AWS Region `${AWS_REGION}` in AWS Account `${A
 
  Check for CloudTrail integration with CloudWatch Logs in AWS Region `${AWS_REGION}` in AWS Account `${AWS_ACCOUNT_ID}`
     [Documentation]    Check for CloudTrail integration with CloudWatch Logs
-    [Tags]    aws    cloudtrail    cloudwatch    logs
+    [Tags]    aws    cloudtrail    cloudwatch    logs    data:config
     ${c7n_output}=    RW.CLI.Run Cli
     ...    cmd=custodian run -r ${AWS_REGION} --output-dir ${OUTPUT_DIR}/aws-c7n-monitoring-health ${CURDIR}/trail-without-cloudwatch-logs.yaml --cache-period 0
-    ...    secret__aws_access_key_id=${AWS_ACCESS_KEY_ID}
-    ...    secret__aws_secret_access_key=${AWS_SECRET_ACCESS_KEY}
+    ...    env=${env}
 
     ${report_data}=     RW.CLI.Run Cli
     ...    cmd=cat ${OUTPUT_DIR}/aws-c7n-monitoring-health/trail-without-cloudwatch-logs/resources.json
@@ -164,16 +160,16 @@ Suite Initialization
     ...    type=string
     ...    description=AWS Account ID
     ...    pattern=\w*
-    ${AWS_ACCESS_KEY_ID}=    RW.Core.Import Secret   AWS_ACCESS_KEY_ID
+    ${aws_credentials}=    RW.Core.Import Secret    aws_credentials
     ...    type=string
-    ...    description=AWS Access Key ID
-    ...    pattern=\w*
-    ${AWS_SECRET_ACCESS_KEY}=    RW.Core.Import Secret   AWS_SECRET_ACCESS_KEY
-    ...    type=string
-    ...    description=AWS Access Key Secret
+    ...    description=AWS credentials from the workspace (from aws-auth block; e.g. aws:access_key@cli, aws:irsa@cli).
     ...    pattern=\w*
     ${clean_workding_dir}=    RW.CLI.Run Cli    cmd=rm -rf ${OUTPUT_DIR}/aws-c7n-monitoring-health
     Set Suite Variable    ${AWS_REGION}    ${AWS_REGION}
     Set Suite Variable    ${AWS_ACCOUNT_ID}    ${AWS_ACCOUNT_ID}
-    Set Suite Variable    ${AWS_ACCESS_KEY_ID}    ${AWS_ACCESS_KEY_ID}
-    Set Suite Variable    ${AWS_SECRET_ACCESS_KEY}    ${AWS_SECRET_ACCESS_KEY} 
+    Set Suite Variable    ${aws_credentials}    ${aws_credentials}
+    # AWS credentials are provided by the platform from the aws-auth block (runwhen-local);
+    # the runtime uses aws_utils to set up the auth environment (IRSA, access key, assume role, etc.).
+    Set Suite Variable
+    ...    &{env}
+    ...    AWS_REGION=${AWS_REGION}

--- a/codebundles/aws-c7n-monitoring-health/sli.robot
+++ b/codebundles/aws-c7n-monitoring-health/sli.robot
@@ -14,11 +14,10 @@ Suite Setup    Suite Initialization
 *** Tasks ***
 Check CloudWatch Log Groups Without Retention Period in AWS Region `${AWS_REGION}` in AWS account `${AWS_ACCOUNT_ID}`
     [Documentation]  Check CloudWatch Log Groups without retention period
-    [Tags]    aws    cloudwatch    logs
+    [Tags]    aws    cloudwatch    logs    data:config
     ${c7n_output}=    RW.CLI.Run Cli
     ...    cmd=custodian run -r ${AWS_REGION} --output-dir ${OUTPUT_DIR}/aws-c7n-monitoring-health ${CURDIR}/log-groups-no-retention.yaml --cache-period 0
-    ...    secret__aws_access_key_id=${AWS_ACCESS_KEY_ID}
-    ...    secret__aws_secret_access_key=${AWS_SECRET_ACCESS_KEY}
+    ...    env=${env}
     ${count}=     RW.CLI.Run Cli
     ...    cmd=cat ${OUTPUT_DIR}/aws-c7n-monitoring-health/log-groups-no-retention/metadata.json | jq '.metrics[] | select(.MetricName == "ResourceCount") | .Value';
     ${no_retention_score}=    Evaluate    1 if int(${count.stdout}) <= int(${MAX_LOG_GROUPS_ALLOWED}) else 0
@@ -26,11 +25,10 @@ Check CloudWatch Log Groups Without Retention Period in AWS Region `${AWS_REGION
 
 Check if CloudTrail exists and is configured for multi-region in AWS Region `${AWS_REGION}` in AWS Account `${AWS_ACCOUNT_ID}`
     [Documentation]    Check if CloudTrail exists and is configured for multi-region
-    [Tags]    aws    cloudtrail    logs
+    [Tags]    aws    cloudtrail    logs    data:config
     ${c7n_output}=    RW.CLI.Run Cli
     ...    cmd=custodian run -r ${AWS_REGION} --output-dir ${OUTPUT_DIR}/aws-c7n-monitoring-health ${CURDIR}/list-trail.yaml --cache-period 0
-    ...    secret__aws_access_key_id=${AWS_ACCESS_KEY_ID}
-    ...    secret__aws_secret_access_key=${AWS_SECRET_ACCESS_KEY}
+    ...    env=${env}
 
     ${report_data}=     RW.CLI.Run Cli
     ...    cmd=cat ${OUTPUT_DIR}/aws-c7n-monitoring-health/list-cloudtrail-trails/resources.json
@@ -49,8 +47,7 @@ Check if CloudTrail exists and is configured for multi-region in AWS Region `${A
         # Check for multi-region trails
         ${c7n_output}=    RW.CLI.Run Cli
         ...    cmd=custodian run -r ${AWS_REGION} --output-dir ${OUTPUT_DIR}/aws-c7n-monitoring-health ${CURDIR}/trail-no-multi-region.yaml --cache-period 0
-        ...    secret__aws_access_key_id=${AWS_ACCESS_KEY_ID}
-        ...    secret__aws_secret_access_key=${AWS_SECRET_ACCESS_KEY}
+        ...    env=${env}
 
         ${report_data}=     RW.CLI.Run Cli
         ...    cmd=cat ${OUTPUT_DIR}/aws-c7n-monitoring-health/trail-no-multi-region/resources.json
@@ -70,11 +67,10 @@ Check if CloudTrail exists and is configured for multi-region in AWS Region `${A
 
 Check CloudTrail Without CloudWatch Logs in AWS Region `${AWS_REGION}` in AWS Account `${AWS_ACCOUNT_ID}`
     [Documentation]    Check if CloudTrail exists and is configured for multi-region in AWS Region `${AWS_REGION}` in AWS Account `${AWS_ACCOUNT_ID}`
-    [Tags]    aws    cloudtrail    cloudwatch    logs
+    [Tags]    aws    cloudtrail    cloudwatch    logs    data:config
     ${c7n_output}=    RW.CLI.Run Cli
     ...    cmd=custodian run -r ${AWS_REGION} --output-dir ${OUTPUT_DIR}/aws-c7n-monitoring-health ${CURDIR}/trail-without-cloudwatch-logs.yaml --cache-period 0
-    ...    secret__aws_access_key_id=${AWS_ACCESS_KEY_ID}
-    ...    secret__aws_secret_access_key=${AWS_SECRET_ACCESS_KEY}
+    ...    env=${env}
 
     ${report_data}=     RW.CLI.Run Cli
     ...    cmd=cat ${OUTPUT_DIR}/aws-c7n-monitoring-health/trail-without-cloudwatch-logs/resources.json
@@ -104,13 +100,9 @@ Suite Initialization
     ...    type=string
     ...    description=AWS Account ID
     ...    pattern=\w*
-    ${AWS_ACCESS_KEY_ID}=    RW.Core.Import Secret   AWS_ACCESS_KEY_ID
+    ${aws_credentials}=    RW.Core.Import Secret    aws_credentials
     ...    type=string
-    ...    description=AWS Access Key ID
-    ...    pattern=\w*
-    ${AWS_SECRET_ACCESS_KEY}=    RW.Core.Import Secret   AWS_SECRET_ACCESS_KEY
-    ...    type=string
-    ...    description=AWS Access Key Secret
+    ...    description=AWS credentials from the workspace (from aws-auth block; e.g. aws:access_key@cli, aws:irsa@cli).
     ...    pattern=\w*
     ${MAX_LOG_GROUPS_ALLOWED}=    RW.Core.Import User Variable    MAX_LOG_GROUPS_ALLOWED
     ...    type=string
@@ -135,5 +127,9 @@ Suite Initialization
     Set Suite Variable    ${AWS_ACCOUNT_ID}    ${AWS_ACCOUNT_ID}
     Set Suite Variable    ${MAX_LOG_GROUPS_ALLOWED}    ${MAX_LOG_GROUPS_ALLOWED}
     Set Suite Variable    ${MAX_CLOUDTRAIL_TRAILS_WITHOUT_CLOUDWATCH_LOGS_ALLOWED}    ${MAX_CLOUDTRAIL_TRAILS_WITHOUT_CLOUDWATCH_LOGS_ALLOWED}
-    Set Suite Variable    ${AWS_ACCESS_KEY_ID}    ${AWS_ACCESS_KEY_ID}
-    Set Suite Variable    ${AWS_SECRET_ACCESS_KEY}    ${AWS_SECRET_ACCESS_KEY} 
+    Set Suite Variable    ${aws_credentials}    ${aws_credentials}
+    # AWS credentials are provided by the platform from the aws-auth block (runwhen-local);
+    # the runtime uses aws_utils to set up the auth environment (IRSA, access key, assume role, etc.).
+    Set Suite Variable
+    ...    &{env}
+    ...    AWS_REGION=${AWS_REGION}

--- a/codebundles/aws-c7n-network-health/.runwhen/templates/aws-c7n-network-health-sli.yaml
+++ b/codebundles/aws-c7n-network-health/.runwhen/templates/aws-c7n-network-health-sli.yaml
@@ -32,10 +32,7 @@ spec:
     - name: AWS_ACCOUNT_ID
       value: "{{match_resource.resource.account_id}}"
   secretsProvided:
-    - name: AWS_ACCESS_KEY_ID
-      workspaceKey: {{custom.aws_access_key_id}}
-    - name: AWS_SECRET_ACCESS_KEY
-      workspaceKey: {{custom.aws_secret_access_key}}
+    {% include "aws-auth.yaml" ignore missing %}
   alerts:
     warning:
       operator: <

--- a/codebundles/aws-c7n-network-health/.runwhen/templates/aws-c7n-network-health-taskset.yaml
+++ b/codebundles/aws-c7n-network-health/.runwhen/templates/aws-c7n-network-health-taskset.yaml
@@ -27,7 +27,4 @@ spec:
     - name: AWS_ACCOUNT_ID
       value: "{{match_resource.resource.account_id}}"
   secretsProvided:
-    - name: AWS_ACCESS_KEY_ID
-      workspaceKey: {{custom.aws_access_key_id}}
-    - name: AWS_SECRET_ACCESS_KEY
-      workspaceKey: {{custom.aws_secret_access_key}}
+    {% include "aws-auth.yaml" ignore missing %}

--- a/codebundles/aws-c7n-network-health/runbook.robot
+++ b/codebundles/aws-c7n-network-health/runbook.robot
@@ -15,15 +15,14 @@ Suite Setup    Suite Initialization
 *** Tasks ***
 List Publicly Accessible Security Groups in AWS account `${AWS_ACCOUNT_ID}` 
     [Documentation]  Find publicly accessible security groups (e.g., "0.0.0.0/0" or "::/0")
-    [Tags]    tag    aws    security-group    network 
+    [Tags]    tag    aws    security-group    network    data:config
     CloudCustodian.Core.Generate Policy   
     ...    ${CURDIR}/insecure-sg-ingress.j2    
     ...    tags=${AWS_SECURITY_GROUP_TAGS}
     FOR    ${region}    IN    @{AWS_ENABLED_REGIONS}
         ${c7n_output}=    RW.CLI.Run Cli
         ...    cmd=custodian run -r ${region} --output-dir ${OUTPUT_DIR}/${region}/aws-c7n-network-health ${CURDIR}/insecure-sg-ingress.yaml --cache-period 0
-        ...    secret__aws_access_key_id=${AWS_ACCESS_KEY_ID}
-        ...    secret__aws_secret_access_key=${AWS_SECRET_ACCESS_KEY}
+    ...    env=${env}
 
         ${report_data}=     RW.CLI.Run Cli
         ...    cmd=cat ${OUTPUT_DIR}/${region}/aws-c7n-network-health/insecure-sg-ingress/resources.json 
@@ -57,12 +56,11 @@ List Publicly Accessible Security Groups in AWS account `${AWS_ACCOUNT_ID}`
 
 List unused Elastic IPs in AWS account `${AWS_ACCOUNT_ID}`
     [Documentation]  Find unused Elastic IPs that are not associated with any instance or network interface
-    [Tags]    aws    eip    network 
+    [Tags]    aws    eip    network    data:config
     FOR    ${region}    IN    @{AWS_ENABLED_REGIONS}
         ${c7n_output}=    RW.CLI.Run Cli
         ...    cmd=custodian run -r ${region} --output-dir ${OUTPUT_DIR}/${region}/aws-c7n-network-health ${CURDIR}/unused-eip.yaml --cache-period 0
-        ...    secret__aws_access_key_id=${AWS_ACCESS_KEY_ID}
-        ...    secret__aws_secret_access_key=${AWS_SECRET_ACCESS_KEY}
+    ...    env=${env}
 
         ${report_data}=     RW.CLI.Run Cli
         ...    cmd=cat ${OUTPUT_DIR}/${region}/aws-c7n-network-health/unused-eip/resources.json 
@@ -98,12 +96,11 @@ List unused Elastic IPs in AWS account `${AWS_ACCOUNT_ID}`
 
 List unused ELBs in AWS account `${AWS_ACCOUNT_ID}`
     [Documentation]  Find unused Application Load Balancers (ALBs) and Network Load Balancers (NLBs) that do not have any associated targets
-    [Tags]    aws    elb    network
+    [Tags]    aws    elb    network    data:config
     FOR    ${region}    IN    @{AWS_ENABLED_REGIONS}
         ${c7n_output}=    RW.CLI.Run Cli
         ...    cmd=custodian run -r ${region} --output-dir ${OUTPUT_DIR}/${region}/aws-c7n-elb-health ${CURDIR}/unused-elb.yaml --cache-period 0
-        ...    secret__aws_access_key_id=${AWS_ACCESS_KEY_ID}
-        ...    secret__aws_secret_access_key=${AWS_SECRET_ACCESS_KEY}
+    ...    env=${env}
 
         ${report_data}=     RW.CLI.Run Cli
         ...    cmd=cat ${OUTPUT_DIR}/${region}/aws-c7n-elb-health/unused-elb/resources.json
@@ -139,15 +136,14 @@ List unused ELBs in AWS account `${AWS_ACCOUNT_ID}`
 
 List VPCs with Flow Logs Disabled in AWS account `${AWS_ACCOUNT_ID}`
     [Documentation]  Find VPCs that do not have flow logs enabled
-    [Tags]    aws    vpc    network
+    [Tags]    aws    vpc    network    data:config
     CloudCustodian.Core.Generate Policy   
     ...    ${CURDIR}/flow-log-disabled-vpc.j2    
     ...    tags=${AWS_VPC_TAGS} 
     FOR    ${region}    IN    @{AWS_ENABLED_REGIONS}
         ${c7n_output}=    RW.CLI.Run Cli
         ...    cmd=custodian run -r ${region} --output-dir ${OUTPUT_DIR}/${region}/aws-c7n-network-health ${CURDIR}/flow-log-disabled-vpc.yaml --cache-period 0
-        ...    secret__aws_access_key_id=${AWS_ACCESS_KEY_ID}
-        ...    secret__aws_secret_access_key=${AWS_SECRET_ACCESS_KEY}
+    ...    env=${env}
 
         ${report_data}=     RW.CLI.Run Cli
         ...    cmd=cat ${OUTPUT_DIR}/${region}/aws-c7n-network-health/flow-log-disabled-vpc/resources.json 
@@ -189,13 +185,9 @@ Suite Initialization
     ...    type=string
     ...    description=AWS Account ID
     ...    pattern=\w*
-    ${AWS_ACCESS_KEY_ID}=    RW.Core.Import Secret   AWS_ACCESS_KEY_ID
+    ${aws_credentials}=    RW.Core.Import Secret    aws_credentials
     ...    type=string
-    ...    description=AWS Access Key ID
-    ...    pattern=\w*
-    ${AWS_SECRET_ACCESS_KEY}=    RW.Core.Import Secret   AWS_SECRET_ACCESS_KEY
-    ...    type=string
-    ...    description=AWS Access Key Secret
+    ...    description=AWS credentials from the workspace (from aws-auth block; e.g. aws:access_key@cli, aws:irsa@cli).
     ...    pattern=\w*
     ${AWS_SECURITY_GROUP_TAGS}=    RW.Core.Import User Variable  AWS_SECURITY_GROUP_TAGS
     ...    type=string
@@ -210,15 +202,18 @@ Suite Initialization
     ...    example="Name,Environment=prod"
     ...    default="Name"
     ${clean_workding_dir}=    RW.CLI.Run Cli    cmd=rm -rf ${OUTPUT_DIR}/aws-c7n-network-health         # Note: Clean out the cloud custoding report dir to ensure accurate data
+    # AWS credentials are provided by the platform from the aws-auth block (runwhen-local);
+    # the runtime uses aws_utils to set up the auth environment (IRSA, access key, assume role, etc.).
+    Set Suite Variable
+    ...    &{env}
+    ...    AWS_REGION=${AWS_REGION}
     ${AWS_ENABLED_REGIONS}=    RW.CLI.Run Cli
     ...    cmd=aws ec2 describe-regions --region ${AWS_REGION} --query 'Regions[*].RegionName' --output json
-    ...    secret__aws_access_key_id=${AWS_ACCESS_KEY_ID}
-    ...    secret__aws_secret_access_key=${AWS_SECRET_ACCESS_KEY}
+    ...    env=${env}
     ${AWS_ENABLED_REGIONS}=    Evaluate    json.loads(r'''${AWS_ENABLED_REGIONS.stdout}''')    json
     Set Suite Variable    ${AWS_ENABLED_REGIONS}    ${AWS_ENABLED_REGIONS}
     Set Suite Variable    ${AWS_REGION}    ${AWS_REGION}
     Set Suite Variable    ${AWS_SECURITY_GROUP_TAGS}    ${AWS_SECURITY_GROUP_TAGS}
     Set Suite Variable    ${AWS_VPC_TAGS}    ${AWS_VPC_TAGS}
     Set Suite Variable    ${AWS_ACCOUNT_ID}    ${AWS_ACCOUNT_ID}
-    Set Suite Variable    ${AWS_ACCESS_KEY_ID}    ${AWS_ACCESS_KEY_ID}
-    Set Suite Variable    ${AWS_SECRET_ACCESS_KEY}    ${AWS_SECRET_ACCESS_KEY}
+    Set Suite Variable    ${aws_credentials}    ${aws_credentials}

--- a/codebundles/aws-c7n-network-health/sli.robot
+++ b/codebundles/aws-c7n-network-health/sli.robot
@@ -15,7 +15,7 @@ Suite Setup    Suite Initialization
 *** Tasks ***
 Check for publicly accessible security groups in AWS account `${AWS_ACCOUNT_ID}`
     [Documentation]  Find publicly accessible security groups (e.g., "0.0.0.0/0" or "::/0")
-    [Tags]    aws    security-group    network
+    [Tags]    aws    security-group    network    data:config
     CloudCustodian.Core.Generate Policy   
     ...    ${CURDIR}/insecure-sg-ingress.j2    
     ...    tags=${AWS_SECURITY_GROUP_TAGS}
@@ -23,8 +23,7 @@ Check for publicly accessible security groups in AWS account `${AWS_ACCOUNT_ID}`
     FOR    ${region}    IN    @{AWS_ENABLED_REGIONS}
         ${c7n_output}=    RW.CLI.Run Cli
         ...    cmd=custodian run -r ${region} --output-dir ${OUTPUT_DIR}/${region}/aws-c7n-network-health ${CURDIR}/insecure-sg-ingress.yaml --cache-period 0
-        ...    secret__aws_access_key_id=${AWS_ACCESS_KEY_ID}
-        ...    secret__aws_secret_access_key=${AWS_SECRET_ACCESS_KEY}
+    ...    env=${env}
         ${count}=     RW.CLI.Run Cli
         ...    cmd=cat ${OUTPUT_DIR}/${region}/aws-c7n-network-health/insecure-sg-ingress/metadata.json | jq '.metrics[] | select(.MetricName == "ResourceCount") | .Value';
         ${total_count}=    Evaluate    ${total_count} + int(${count.stdout})
@@ -35,13 +34,12 @@ Check for publicly accessible security groups in AWS account `${AWS_ACCOUNT_ID}`
 
 Check for unused Elastic IPs in AWS account `${AWS_ACCOUNT_ID}`
     [Documentation]  Find unused Elastic IPs that are not associated with any instance or network interface
-    [Tags]    aws    eip    network 
+    [Tags]    aws    eip    network    data:config
     ${total_count}=    Set Variable    0
     FOR    ${region}    IN    @{AWS_ENABLED_REGIONS}
         ${c7n_output}=    RW.CLI.Run Cli
         ...    cmd=custodian run -r ${region} --output-dir ${OUTPUT_DIR}/${region}/aws-c7n-network-health ${CURDIR}/unused-eip.yaml --cache-period 0
-        ...    secret__aws_access_key_id=${AWS_ACCESS_KEY_ID}
-        ...    secret__aws_secret_access_key=${AWS_SECRET_ACCESS_KEY}
+    ...    env=${env}
         ${count}=     RW.CLI.Run Cli
         ...    cmd=cat ${OUTPUT_DIR}/${region}/aws-c7n-network-health/unused-eip/metadata.json | jq '.metrics[] | select(.MetricName == "ResourceCount") | .Value';
         ${total_count}=    Evaluate    ${total_count} + int(${count.stdout})
@@ -51,13 +49,12 @@ Check for unused Elastic IPs in AWS account `${AWS_ACCOUNT_ID}`
 
 Check for unused ELBs in AWS account `${AWS_ACCOUNT_ID}`
     [Documentation]  Find unused Application Load Balancers (ALBs) and Network Load Balancers (NLBs) that do not have any associated targets
-    [Tags]    aws    elb    network 
+    [Tags]    aws    elb    network    data:config
     ${total_count}=    Set Variable    0
     FOR    ${region}    IN    @{AWS_ENABLED_REGIONS}
         ${c7n_output}=    RW.CLI.Run Cli
         ...    cmd=custodian run -r ${region} --output-dir ${OUTPUT_DIR}/${region}/aws-c7n-network-health ${CURDIR}/unused-elb.yaml --cache-period 0
-        ...    secret__aws_access_key_id=${AWS_ACCESS_KEY_ID}
-        ...    secret__aws_secret_access_key=${AWS_SECRET_ACCESS_KEY}
+    ...    env=${env}
         ${count}=     RW.CLI.Run Cli
         ...    cmd=cat ${OUTPUT_DIR}/${region}/aws-c7n-network-health/unused-elb/metadata.json | jq '.metrics[] | select(.MetricName == "ResourceCount") | .Value';
         ${total_count}=    Evaluate    ${total_count} + int(${count.stdout})
@@ -67,7 +64,7 @@ Check for unused ELBs in AWS account `${AWS_ACCOUNT_ID}`
 
 Check for VPCs with Flow Logs disabled in AWS account `${AWS_ACCOUNT_ID}`
     [Documentation]  Find VPCs that do not have Flow Logs enabled
-    [Tags]    aws    vpc    network 
+    [Tags]    aws    vpc    network    data:config
     CloudCustodian.Core.Generate Policy   
     ...    ${CURDIR}/flow-log-disabled-vpc.j2    
     ...    tags=${AWS_VPC_TAGS}
@@ -75,8 +72,7 @@ Check for VPCs with Flow Logs disabled in AWS account `${AWS_ACCOUNT_ID}`
     FOR    ${region}    IN    @{AWS_ENABLED_REGIONS}
         ${c7n_output}=    RW.CLI.Run Cli
         ...    cmd=custodian run -r ${region} --output-dir ${OUTPUT_DIR}/${region}/aws-c7n-network-health ${CURDIR}/flow-log-disabled-vpc.yaml --cache-period 0
-        ...    secret__aws_access_key_id=${AWS_ACCESS_KEY_ID}
-        ...    secret__aws_secret_access_key=${AWS_SECRET_ACCESS_KEY}
+    ...    env=${env}
         ${count}=     RW.CLI.Run Cli
         ...    cmd=cat ${OUTPUT_DIR}/${region}/aws-c7n-network-health/flow-log-disabled-vpc/metadata.json | jq '.metrics[] | select(.MetricName == "ResourceCount") | .Value';
         ${total_count}=    Evaluate    ${total_count} + int(${count.stdout})
@@ -99,13 +95,9 @@ Suite Initialization
     ...    type=string
     ...    description=AWS Account ID
     ...    pattern=\w*
-    ${AWS_ACCESS_KEY_ID}=    RW.Core.Import Secret   AWS_ACCESS_KEY_ID
+    ${aws_credentials}=    RW.Core.Import Secret    aws_credentials
     ...    type=string
-    ...    description=AWS Access Key ID
-    ...    pattern=\w*
-    ${AWS_SECRET_ACCESS_KEY}=    RW.Core.Import Secret   AWS_SECRET_ACCESS_KEY
-    ...    type=string
-    ...    description=AWS Access Key Secret
+    ...    description=AWS credentials from the workspace (from aws-auth block; e.g. aws:access_key@cli, aws:irsa@cli).
     ...    pattern=\w*
     ${UNSECURED_SG_THRESHOLD}=    RW.Core.Import User Variable    UNSECURED_SG_THRESHOLD
     ...    type=string
@@ -138,10 +130,14 @@ Suite Initialization
     ...    example="Name,Environment=prod"
     ...    default="Name"
     ${clean_workding_dir}=    RW.CLI.Run Cli    cmd=rm -rf ${OUTPUT_DIR}/aws-c7n-network-health         # Note: Clean out the cloud custoding report dir to ensure accurate data
+    # AWS credentials are provided by the platform from the aws-auth block (runwhen-local);
+    # the runtime uses aws_utils to set up the auth environment (IRSA, access key, assume role, etc.).
+    Set Suite Variable
+    ...    &{env}
+    ...    AWS_REGION=${AWS_REGION}
     ${AWS_ENABLED_REGIONS}=    RW.CLI.Run Cli
     ...    cmd=aws ec2 describe-regions --region ${AWS_REGION} --query 'Regions[*].RegionName' --output json
-    ...    secret__aws_access_key_id=${AWS_ACCESS_KEY_ID}
-    ...    secret__aws_secret_access_key=${AWS_SECRET_ACCESS_KEY}
+    ...    env=${env}
     ${AWS_ENABLED_REGIONS}=    Evaluate    json.loads(r'''${AWS_ENABLED_REGIONS.stdout}''')    json
     Set Suite Variable    ${AWS_ENABLED_REGIONS}    ${AWS_ENABLED_REGIONS}
     Set Suite Variable    ${AWS_REGION}    ${AWS_REGION}
@@ -149,7 +145,6 @@ Suite Initialization
     Set Suite Variable    ${AWS_VPC_TAGS}    ${AWS_VPC_TAGS}
     Set Suite Variable    ${AWS_ACCOUNT_ID}    ${AWS_ACCOUNT_ID}
     Set Suite Variable    ${UNSECURED_SG_THRESHOLD}    ${UNSECURED_SG_THRESHOLD}
-    Set Suite Variable    ${AWS_ACCESS_KEY_ID}    ${AWS_ACCESS_KEY_ID}
-    Set Suite Variable    ${AWS_SECRET_ACCESS_KEY}    ${AWS_SECRET_ACCESS_KEY}
+    Set Suite Variable    ${aws_credentials}    ${aws_credentials}
     Set Suite Variable    ${DISABLED_FLOW_LOG_THRESHOLD}    ${DISABLED_FLOW_LOG_THRESHOLD}
     Set Suite Variable    ${MAX_ALLOWED_UNUSED_RESOURCES}    ${MAX_ALLOWED_UNUSED_RESOURCES}

--- a/codebundles/aws-c7n-rds-health/.runwhen/templates/aws-c7n-rds-health-sli.yaml
+++ b/codebundles/aws-c7n-rds-health/.runwhen/templates/aws-c7n-rds-health-sli.yaml
@@ -32,10 +32,7 @@ spec:
     - name: AWS_ACCOUNT_ID
       value: "{{match_resource.resource.account_id}}"
   secretsProvided:
-    - name: AWS_ACCESS_KEY_ID
-      workspaceKey: {{custom.aws_access_key_id}}
-    - name: AWS_SECRET_ACCESS_KEY
-      workspaceKey: {{custom.aws_secret_access_key}}
+    {% include "aws-auth.yaml" ignore missing %}
   alerts:
     warning:
       operator: <

--- a/codebundles/aws-c7n-rds-health/.runwhen/templates/aws-c7n-rds-health-taskset.yaml
+++ b/codebundles/aws-c7n-rds-health/.runwhen/templates/aws-c7n-rds-health-taskset.yaml
@@ -27,7 +27,4 @@ spec:
     - name: AWS_ACCOUNT_ID
       value: "{{match_resource.resource.account_id}}"
   secretsProvided:
-    - name: AWS_ACCESS_KEY_ID
-      workspaceKey: {{custom.aws_access_key_id}}
-    - name: AWS_SECRET_ACCESS_KEY
-      workspaceKey: {{custom.aws_secret_access_key}}
+    {% include "aws-auth.yaml" ignore missing %}

--- a/codebundles/aws-c7n-rds-health/runbook.robot
+++ b/codebundles/aws-c7n-rds-health/runbook.robot
@@ -14,11 +14,10 @@ Suite Setup    Suite Initialization
 *** Tasks ***
 List Unencrypted RDS Instances in AWS Region `${AWS_REGION}` in AWS Account `${AWS_ACCOUNT_ID}`
     [Documentation]  Find unencrypted RDS instances
-    [Tags]    aws    rds    database    encryption 
+    [Tags]    aws    rds    database    encryption    data:config
     ${c7n_output}=    RW.CLI.Run Cli
     ...    cmd=custodian run -r ${AWS_REGION} --output-dir ${OUTPUT_DIR}/aws-c7n-rds-health ${CURDIR}/unencrypted-rds.yaml --cache-period 0
-    ...    secret__aws_access_key_id=${AWS_ACCESS_KEY_ID}
-    ...    secret__aws_secret_access_key=${AWS_SECRET_ACCESS_KEY}
+    ...    env=${env}
 
     ${report_data}=     RW.CLI.Run Cli
     ...    cmd=cat ${OUTPUT_DIR}/aws-c7n-rds-health/unencrypted-rds/resources.json 
@@ -52,11 +51,10 @@ List Unencrypted RDS Instances in AWS Region `${AWS_REGION}` in AWS Account `${A
 
 List Publicly Accessible RDS Instances in AWS Region `${AWS_REGION}` in AWS Account `${AWS_ACCOUNT_ID}`
     [Documentation]  Find publicly accessible RDS instances
-    [Tags]    aws    rds    database    security 
+    [Tags]    aws    rds    database    security    data:config
     ${c7n_output}=    RW.CLI.Run Cli
     ...    cmd=custodian run -r ${AWS_REGION} --output-dir ${OUTPUT_DIR}/aws-c7n-rds-health ${CURDIR}/publicly-accessible-rds.yaml --cache-period 0
-    ...    secret__aws_access_key_id=${AWS_ACCESS_KEY_ID}
-    ...    secret__aws_secret_access_key=${AWS_SECRET_ACCESS_KEY}
+    ...    env=${env}
 
     ${report_data}=     RW.CLI.Run Cli
     ...    cmd=cat ${OUTPUT_DIR}/aws-c7n-rds-health/publicly-accessible-rds/resources.json 
@@ -89,11 +87,10 @@ List Publicly Accessible RDS Instances in AWS Region `${AWS_REGION}` in AWS Acco
 
 List RDS Instances with Backups Disabled in AWS Region `${AWS_REGION}` in AWS Account `${AWS_ACCOUNT_ID}`
     [Documentation]  Identify RDS instances with backups disabled
-    [Tags]    aws    rds    database    backups 
+    [Tags]    aws    rds    database    backups    data:config
     ${c7n_output}=    RW.CLI.Run Cli
     ...    cmd=custodian run -r ${AWS_REGION} --output-dir ${OUTPUT_DIR}/aws-c7n-rds-health ${CURDIR}/backup-disabled-rds.yaml --cache-period 0
-    ...    secret__aws_access_key_id=${AWS_ACCESS_KEY_ID}
-    ...    secret__aws_secret_access_key=${AWS_SECRET_ACCESS_KEY}
+    ...    env=${env}
 
     ${report_data}=     RW.CLI.Run Cli
     ...    cmd=cat ${OUTPUT_DIR}/aws-c7n-rds-health/backup-disabled-rds/resources.json 
@@ -134,16 +131,16 @@ Suite Initialization
     ...    type=string
     ...    description=AWS Account ID
     ...    pattern=\w*
-    ${AWS_ACCESS_KEY_ID}=    RW.Core.Import Secret   AWS_ACCESS_KEY_ID
+    ${aws_credentials}=    RW.Core.Import Secret    aws_credentials
     ...    type=string
-    ...    description=AWS Access Key ID
-    ...    pattern=\w*
-    ${AWS_SECRET_ACCESS_KEY}=    RW.Core.Import Secret   AWS_SECRET_ACCESS_KEY
-    ...    type=string
-    ...    description=AWS Access Key Secret
+    ...    description=AWS credentials from the workspace (from aws-auth block; e.g. aws:access_key@cli, aws:irsa@cli).
     ...    pattern=\w*
     ${clean_workding_dir}=    RW.CLI.Run Cli    cmd=rm -rf ${OUTPUT_DIR}/aws-c7n-rds-health
     Set Suite Variable    ${AWS_REGION}    ${AWS_REGION}
     Set Suite Variable    ${AWS_ACCOUNT_ID}    ${AWS_ACCOUNT_ID}
-    Set Suite Variable    ${AWS_ACCESS_KEY_ID}    ${AWS_ACCESS_KEY_ID}
-    Set Suite Variable    ${AWS_SECRET_ACCESS_KEY}    ${AWS_SECRET_ACCESS_KEY}
+    Set Suite Variable    ${aws_credentials}    ${aws_credentials}
+    # AWS credentials are provided by the platform from the aws-auth block (runwhen-local);
+    # the runtime uses aws_utils to set up the auth environment (IRSA, access key, assume role, etc.).
+    Set Suite Variable
+    ...    &{env}
+    ...    AWS_REGION=${AWS_REGION}

--- a/codebundles/aws-c7n-rds-health/sli.robot
+++ b/codebundles/aws-c7n-rds-health/sli.robot
@@ -14,11 +14,10 @@ Suite Setup    Suite Initialization
 *** Tasks ***
 Check for unencrypted RDS instances in AWS Region `${AWS_REGION}` in AWS account `${AWS_ACCOUNT_ID}`
     [Documentation]  Find unencrypted RDS instances
-    [Tags]    aws    rds    database    encryption 
+    [Tags]    aws    rds    database    encryption    data:config
     ${c7n_output}=    RW.CLI.Run Cli
     ...    cmd=custodian run -r ${AWS_REGION} --output-dir ${OUTPUT_DIR}/aws-c7n-rds-health ${CURDIR}/unencrypted-rds.yaml --cache-period 0
-    ...    secret__aws_access_key_id=${AWS_ACCESS_KEY_ID}
-    ...    secret__aws_secret_access_key=${AWS_SECRET_ACCESS_KEY}
+    ...    env=${env}
     ${count}=     RW.CLI.Run Cli
     ...    cmd=cat ${OUTPUT_DIR}/aws-c7n-rds-health/unencrypted-rds/metadata.json | jq '.metrics[] | select(.MetricName == "ResourceCount") | .Value';
     ${unencrypted_rds_score}=    Evaluate    1 if int(${count.stdout}) <= int(${EVENT_THRESHOLD}) else 0
@@ -26,11 +25,10 @@ Check for unencrypted RDS instances in AWS Region `${AWS_REGION}` in AWS account
 
 Check for publicly accessible RDS instances in AWS Region `${AWS_REGION}` in AWS account `${AWS_ACCOUNT_ID}`
     [Documentation]  Find publicly accessible RDS instances
-    [Tags]    aws    rds    database    security 
+    [Tags]    aws    rds    database    security    data:config
     ${c7n_output}=    RW.CLI.Run Cli
     ...    cmd=custodian run -r ${AWS_REGION} --output-dir ${OUTPUT_DIR}/aws-c7n-rds-health ${CURDIR}/publicly-accessible-rds.yaml --cache-period 0
-    ...    secret__aws_access_key_id=${AWS_ACCESS_KEY_ID}
-    ...    secret__aws_secret_access_key=${AWS_SECRET_ACCESS_KEY}
+    ...    env=${env}
     ${count}=     RW.CLI.Run Cli
     ...    cmd=cat ${OUTPUT_DIR}/aws-c7n-rds-health/publicly-accessible-rds/metadata.json | jq '.metrics[] | select(.MetricName == "ResourceCount") | .Value';
     ${publicly_accessible_rds_score}=    Evaluate    1 if int(${count.stdout}) <= int(${EVENT_THRESHOLD}) else 0
@@ -38,11 +36,10 @@ Check for publicly accessible RDS instances in AWS Region `${AWS_REGION}` in AWS
 
 Check for disabled backup RDS instances in AWS Region `${AWS_REGION}` in AWS account `${AWS_ACCOUNT_ID}`
     [Documentation]  Find RDS instances with backups disabled
-    [Tags]    aws    rds    database    backups
+    [Tags]    aws    rds    database    backups    data:config
     ${c7n_output}=    RW.CLI.Run Cli
     ...    cmd=custodian run -r ${AWS_REGION} --output-dir ${OUTPUT_DIR}/aws-c7n-rds-health ${CURDIR}/backup-disabled-rds.yaml --cache-period 0
-    ...    secret__aws_access_key_id=${AWS_ACCESS_KEY_ID}
-    ...    secret__aws_secret_access_key=${AWS_SECRET_ACCESS_KEY}
+    ...    env=${env}
     ${count}=     RW.CLI.Run Cli
     ...    cmd=cat ${OUTPUT_DIR}/aws-c7n-rds-health/backup-disabled-rds/metadata.json | jq '.metrics[] | select(.MetricName == "ResourceCount") | .Value';
     ${backup_disabled_rds_score}=    Evaluate    1 if int(${count.stdout}) <= int(${EVENT_THRESHOLD}) else 0
@@ -65,13 +62,9 @@ Suite Initialization
     ...    type=string
     ...    description=AWS Account ID
     ...    pattern=\w*
-    ${AWS_ACCESS_KEY_ID}=    RW.Core.Import Secret   AWS_ACCESS_KEY_ID
+    ${aws_credentials}=    RW.Core.Import Secret    aws_credentials
     ...    type=string
-    ...    description=AWS Access Key ID
-    ...    pattern=\w*
-    ${AWS_SECRET_ACCESS_KEY}=    RW.Core.Import Secret   AWS_SECRET_ACCESS_KEY
-    ...    type=string
-    ...    description=AWS Access Key Secret
+    ...    description=AWS credentials from the workspace (from aws-auth block; e.g. aws:access_key@cli, aws:irsa@cli).
     ...    pattern=\w*
     ${EVENT_THRESHOLD}=    RW.Core.Import User Variable    EVENT_THRESHOLD
     ...    type=string
@@ -83,6 +76,10 @@ Suite Initialization
     Set Suite Variable    ${AWS_REGION}    ${AWS_REGION}
     Set Suite Variable    ${AWS_ACCOUNT_ID}    ${AWS_ACCOUNT_ID}
     Set Suite Variable    ${EVENT_THRESHOLD}    ${EVENT_THRESHOLD}
-    Set Suite Variable    ${AWS_ACCESS_KEY_ID}    ${AWS_ACCESS_KEY_ID}
-    Set Suite Variable    ${AWS_SECRET_ACCESS_KEY}    ${AWS_SECRET_ACCESS_KEY}
+    Set Suite Variable    ${aws_credentials}    ${aws_credentials}
+    # AWS credentials are provided by the platform from the aws-auth block (runwhen-local);
+    # the runtime uses aws_utils to set up the auth environment (IRSA, access key, assume role, etc.).
+    Set Suite Variable
+    ...    &{env}
+    ...    AWS_REGION=${AWS_REGION}
 

--- a/codebundles/aws-c7n-s3-health/.runwhen/templates/aws-c7n-s3-health-sli.yaml
+++ b/codebundles/aws-c7n-s3-health/.runwhen/templates/aws-c7n-s3-health-sli.yaml
@@ -32,7 +32,4 @@ spec:
     - name: AWS_ACCOUNT_ID
       value: "{{match_resource.resource.account_id}}"
   secretsProvided:
-    - name: AWS_ACCESS_KEY_ID
-      workspaceKey: {{custom.aws_access_key_id}}
-    - name: AWS_SECRET_ACCESS_KEY
-      workspaceKey: {{custom.aws_secret_access_key}}
+    {% include "aws-auth.yaml" ignore missing %}

--- a/codebundles/aws-c7n-s3-health/.runwhen/templates/aws-c7n-s3-health-taskset.yaml
+++ b/codebundles/aws-c7n-s3-health/.runwhen/templates/aws-c7n-s3-health-taskset.yaml
@@ -27,7 +27,4 @@ spec:
     - name: AWS_ACCOUNT_ID
       value: "{{match_resource.resource.account_id}}"
   secretsProvided:
-    - name: AWS_ACCESS_KEY_ID
-      workspaceKey: {{custom.aws_access_key_id}}
-    - name: AWS_SECRET_ACCESS_KEY
-      workspaceKey: {{custom.aws_secret_access_key}}
+    {% include "aws-auth.yaml" ignore missing %}

--- a/codebundles/aws-c7n-s3-health/runbook.robot
+++ b/codebundles/aws-c7n-s3-health/runbook.robot
@@ -14,11 +14,10 @@ Suite Setup    Suite Initialization
 *** Tasks ***
 List S3 Buckets With Public Access in AWS Account `${AWS_ACCOUNT_NAME}`
     [Documentation]  Fetch total number of S3 buckets with public access enabled and raises an issue if any exist.  
-    [Tags]    s3    storage    aws    security
+    [Tags]    s3    storage    aws    security    data:config
     ${c7n_output}=    RW.CLI.Run Cli
     ...    cmd=custodian run -r ${AWS_REGION} --output-dir ${OUTPUT_DIR}/aws-c7n-s3-health ${CURDIR}/s3-public-buckets.yaml
-    ...    secret__aws_account_id=${AWS_ACCESS_KEY_ID}
-    ...    secret__aws_secret_access_key=${AWS_SECRET_ACCESS_KEY}
+    ...    env=${env}
     ${report_data}=    RW.CLI.Run Cli                                         # Note: This just an example of parsing with the RW.CLI.Run Cli keyword. 
     ...    cmd=cat ${OUTPUT_DIR}/aws-c7n-s3-health/s3-public-buckets/resources.json 
     RW.Core.Add Pre To Report    ${c7n_output.stdout}     # Note: This actual data needs to be parsed to be usable in the report. Json data in a report like this isn't super useful. 
@@ -61,13 +60,9 @@ Suite Initialization
     ...    type=string
     ...    description=AWS Account ID
     ...    pattern=\w*
-    ${AWS_ACCESS_KEY_ID}=    RW.Core.Import Secret   AWS_ACCESS_KEY_ID
+    ${aws_credentials}=    RW.Core.Import Secret    aws_credentials
     ...    type=string
-    ...    description=AWS Access Key ID
-    ...    pattern=\w*
-    ${AWS_SECRET_ACCESS_KEY}=    RW.Core.Import Secret   AWS_SECRET_ACCESS_KEY
-    ...    type=string
-    ...    description=AWS Access Key Secret
+    ...    description=AWS credentials from the workspace (from aws-auth block; e.g. aws:access_key@cli, aws:irsa@cli).
     ...    pattern=\w*
     ${aws_account_name_query}=       RW.CLI.Run Cli    
     ...    cmd=aws organizations describe-account --account-id $(aws sts get-caller-identity --query 'Account' --output text) --query "Account.Name" --output text | tr -d '\n'
@@ -75,3 +70,9 @@ Suite Initialization
     Set Suite Variable    ${AWS_ACCOUNT_NAME}    ${aws_account_name_query.stdout}
     Set Suite Variable    ${AWS_REGION}    ${AWS_REGION}
     Set Suite Variable    ${AWS_ACCOUNT_ID}    ${AWS_ACCOUNT_ID}
+    Set Suite Variable    ${aws_credentials}    ${aws_credentials}
+    # AWS credentials are provided by the platform from the aws-auth block (runwhen-local);
+    # the runtime uses aws_utils to set up the auth environment (IRSA, access key, assume role, etc.).
+    Set Suite Variable
+    ...    &{env}
+    ...    AWS_REGION=${AWS_REGION}

--- a/codebundles/aws-c7n-s3-health/sli.robot
+++ b/codebundles/aws-c7n-s3-health/sli.robot
@@ -13,11 +13,10 @@ Suite Setup    Suite Initialization
 *** Tasks ***
 Count S3 Buckets With Public Access in AWS Account `${AWS_ACCOUNT_NAME}`
     [Documentation]  Fetch total number of S3 buckets with public access enabled.    
-    [Tags]    s3    storage    aws    security
+    [Tags]    s3    storage    aws    security    data:config
     ${c7n_output}=    RW.CLI.Run Cli
     ...    cmd=custodian run -r ${AWS_REGION} --output-dir ${OUTPUT_DIR}/aws-c7n-s3-health ${CURDIR}/s3-public-buckets.yaml
-    ...    secret__aws_account_id=${AWS_ACCESS_KEY_ID}
-    ...    secret__aws_secret_access_key=${AWS_SECRET_ACCESS_KEY}
+    ...    env=${env}
     ${count}=     RW.CLI.Run Cli
     ...    cmd=cat ${OUTPUT_DIR}/aws-c7n-s3-health/s3-public-buckets/metadata.json | jq '.metrics[] | select(.MetricName == "ResourceCount") | .Value'
     RW.Core.Push Metric    ${count.stdout}
@@ -35,13 +34,9 @@ Suite Initialization
     ...    type=string
     ...    description=AWS Account ID
     ...    pattern=\w*
-    ${AWS_ACCESS_KEY_ID}=    RW.Core.Import Secret   AWS_ACCESS_KEY_ID
+    ${aws_credentials}=    RW.Core.Import Secret    aws_credentials
     ...    type=string
-    ...    description=AWS Access Key ID
-    ...    pattern=\w*
-    ${AWS_SECRET_ACCESS_KEY}=    RW.Core.Import Secret   AWS_SECRET_ACCESS_KEY
-    ...    type=string
-    ...    description=AWS Access Key Secret
+    ...    description=AWS credentials from the workspace (from aws-auth block; e.g. aws:access_key@cli, aws:irsa@cli).
     ...    pattern=\w*
     # This may not work without certain permissions. We might just drop this, but unfortuinately a numberd account ID is less human friendly to include in task titles. 
     ${aws_account_name_query}=       RW.CLI.Run Cli    
@@ -50,3 +45,9 @@ Suite Initialization
     Set Suite Variable    ${AWS_ACCOUNT_NAME}    ${aws_account_name_query.stdout}
     Set Suite Variable    ${AWS_REGION}    ${AWS_REGION}
     Set Suite Variable    ${AWS_ACCOUNT_ID}    ${AWS_ACCOUNT_ID}
+    Set Suite Variable    ${aws_credentials}    ${aws_credentials}
+    # AWS credentials are provided by the platform from the aws-auth block (runwhen-local);
+    # the runtime uses aws_utils to set up the auth environment (IRSA, access key, assume role, etc.).
+    Set Suite Variable
+    ...    &{env}
+    ...    AWS_REGION=${AWS_REGION}

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ ruamel.base>=1.0.0
 ruamel.yaml>=0.17.20
 requests>=2
 c7n>=0.9.41
-rw-cli-keywords>=0.0.19
+rw-cli-keywords>=0.0.27


### PR DESCRIPTION
Update AWS health codebundles to use environment variables for AWS credentials and enhance task tagging. Refactor runbooks and SLIs to include 'data:config' tags for better categorization. Remove direct access to AWS access keys in favor of a more secure environment-based approach.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches authentication wiring across many runbooks/SLIs; misconfiguration of the new `aws-auth`/env-based setup could break AWS access at runtime, though business logic is otherwise unchanged.
> 
> **Overview**
> Refactors the AWS c7n health codebundles (ACM, EBS, EC2, Monitoring, Network, RDS, S3) to **stop passing `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` into `RW.CLI.Run Cli`** and instead use a suite-level `&{env}` plus a single imported `aws_credentials` secret.
> 
> Updates SLI/Runbook templates to replace explicit access-key secrets with `{% include "aws-auth.yaml" ignore missing %}`, and adds the `data:config` tag across tasks for improved categorization/metadata. Bumps `rw-cli-keywords` from `0.0.19` to `0.0.27`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3b2e234a8f27ee979b80eb266e4709f0789357f5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->