### PR TITLE
Updates/021826 01

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,24 @@
+name: Release (Date-based)
+
+on:
+  schedule:
+    - cron: '0 12 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: true
+
+      - name: Create Release
+        uses: runwhen-contrib/github-actions/generate-release@main
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/codebundles/aws-c7n-acm-health/.runwhen/templates/aws-c7n-acm-health-sli.yaml
+++ b/codebundles/aws-c7n-acm-health/.runwhen/templates/aws-c7n-acm-health-sli.yaml
@@ -11,7 +11,7 @@ spec:
   displayUnitsShort: ok
   locations:
       - {{default_location}}
-  description: Count AWS ACM certificates that are unused, expiring, expired, or failed in AWS region {{match_resource.resource.region}} and account {{match_resource.resource.account_id}}
+  description: Count AWS ACM certificates that are unused, expiring, expired, or failed in AWS region {{match_resource.resource.region}} and account {{match_resource.account_name}}
   codeBundle:
     {% if repo_url %}
     repoUrl: {{repo_url}}

--- a/codebundles/aws-c7n-acm-health/.runwhen/templates/aws-c7n-acm-health-sli.yaml
+++ b/codebundles/aws-c7n-acm-health/.runwhen/templates/aws-c7n-acm-health-sli.yaml
@@ -31,6 +31,8 @@ spec:
       value: "{{match_resource.resource.region}}"
     - name: AWS_ACCOUNT_ID
       value: "{{match_resource.resource.account_id}}"
+    - name: AWS_ACCOUNT_NAME
+      value: "{{match_resource.account_name}}"
   secretsProvided:
     {% include "aws-auth.yaml" ignore missing %}
   alerts:

--- a/codebundles/aws-c7n-acm-health/.runwhen/templates/aws-c7n-acm-health-slx.yaml
+++ b/codebundles/aws-c7n-acm-health/.runwhen/templates/aws-c7n-acm-health-slx.yaml
@@ -8,8 +8,8 @@ metadata:
     {% include "common-annotations.yaml" %}
 spec:
   imageURL: https://storage.googleapis.com/runwhen-nonprod-shared-images/icons/aws/certificate_manager.svg
-  alias: AWS ACM Health For Region {{match_resource.resource.region}} in Account {{match_resource.resource.account_id}}
-  asMeasuredBy: The number of AWS ACM certificates that are unused, expiring or expired and failed status in region {{match_resource.resource.region}} and account {{match_resource.resource.account_id}}
+  alias: AWS ACM Health For Region {{match_resource.resource.region}} in Account {{match_resource.account_name}}
+  asMeasuredBy: The number of AWS ACM certificates that are unused, expiring or expired and failed status in region {{match_resource.resource.region}} and account {{match_resource.account_name}}
   configProvided:
   - name: SLX_PLACEHOLDER
     value: SLX_PLACEHOLDER

--- a/codebundles/aws-c7n-acm-health/.runwhen/templates/aws-c7n-acm-health-taskset.yaml
+++ b/codebundles/aws-c7n-acm-health/.runwhen/templates/aws-c7n-acm-health-taskset.yaml
@@ -26,5 +26,7 @@ spec:
       value: "{{match_resource.resource.region}}"
     - name: AWS_ACCOUNT_ID
       value: "{{match_resource.resource.account_id}}"
+    - name: AWS_ACCOUNT_NAME
+      value: "{{match_resource.account_name}}"
   secretsProvided:
     {% include "aws-auth.yaml" ignore missing %}

--- a/codebundles/aws-c7n-acm-health/runbook.robot
+++ b/codebundles/aws-c7n-acm-health/runbook.robot
@@ -12,7 +12,7 @@ Library    CloudCustodian.Core
 Suite Setup    Suite Initialization
 
 *** Tasks ***
-List Unused ACM Certificates in AWS Region `${AWS_REGION}` in AWS Account `${AWS_ACCOUNT_ID}`
+List Unused ACM Certificates in AWS Region `${AWS_REGION}` in AWS Account `${AWS_ACCOUNT_NAME}`
     [Documentation]  Find unused ACM certificates
     [Tags]    aws    acm    certificate    security    data:config
     ${c7n_output}=    RW.CLI.Run Cli
@@ -54,7 +54,7 @@ List Unused ACM Certificates in AWS Region `${AWS_REGION}` in AWS Account `${AWS
         RW.Core.Add Pre To Report    No unused ACM certificates found in AWS Region `${AWS_REGION}` in AWS Account `${AWS_ACCOUNT_ID}`
     END
 
-List Expiring ACM Certificates in AWS Region `${AWS_REGION}` in AWS Account `${AWS_ACCOUNT_ID}`
+List Expiring ACM Certificates in AWS Region `${AWS_REGION}` in AWS Account `${AWS_ACCOUNT_NAME}`
     [Documentation]  Find Expiring ACM certificates
     [Tags]    aws    acm    certificate    expiration    data:config
     CloudCustodian.Core.Generate Policy   
@@ -100,7 +100,7 @@ List Expiring ACM Certificates in AWS Region `${AWS_REGION}` in AWS Account `${A
         RW.Core.Add Pre To Report    No ACM certificates nearing expiration found in AWS Region `${AWS_REGION}` in AWS Account `${AWS_ACCOUNT_ID}`
     END
 
-List Expired ACM Certificates in AWS Region `${AWS_REGION}` in AWS Account `${AWS_ACCOUNT_ID}`
+List Expired ACM Certificates in AWS Region `${AWS_REGION}` in AWS Account `${AWS_ACCOUNT_NAME}`
     [Documentation]  Find expired ACM certificates
     [Tags]    aws    acm    certificate    expiration    data:config
     ${c7n_output}=    RW.CLI.Run Cli
@@ -141,7 +141,7 @@ List Expired ACM Certificates in AWS Region `${AWS_REGION}` in AWS Account `${AW
         RW.Core.Add Pre To Report    No expired ACM certificates found in AWS Region `${AWS_REGION}` in AWS Account `${AWS_ACCOUNT_ID}`
     END
 
-List Failed Status ACM Certificates in AWS Region `${AWS_REGION}` in AWS Account `${AWS_ACCOUNT_ID}`
+List Failed Status ACM Certificates in AWS Region `${AWS_REGION}` in AWS Account `${AWS_ACCOUNT_NAME}`
     [Documentation]  Find failed status ACM certificates
     [Tags]    aws    acm    certificate    status    data:config
     ${c7n_output}=    RW.CLI.Run Cli
@@ -183,7 +183,7 @@ List Failed Status ACM Certificates in AWS Region `${AWS_REGION}` in AWS Account
         RW.Core.Add Pre To Report    No ACM certificates in failed status found in AWS Region `${AWS_REGION}` in AWS Account `${AWS_ACCOUNT_ID}`
     END
 
-List Pending Validation ACM Certificates in AWS Region `${AWS_REGION}` in AWS Account `${AWS_ACCOUNT_ID}`
+List Pending Validation ACM Certificates in AWS Region `${AWS_REGION}` in AWS Account `${AWS_ACCOUNT_NAME}`
     [Documentation]  Find pending validation ACM certificates
     [Tags]    aws    acm    certificate    status    data:config
     ${c7n_output}=    RW.CLI.Run Cli
@@ -236,6 +236,10 @@ Suite Initialization
     ...    type=string
     ...    description=AWS Account ID
     ...    pattern=\w*
+    ${AWS_ACCOUNT_NAME}=    RW.Core.Import User Variable   AWS_ACCOUNT_NAME
+    ...    type=string
+    ...    description=AWS Account Name
+    ...    pattern=\w*
     ${aws_credentials}=    RW.Core.Import Secret    aws_credentials
     ...    type=string
     ...    description=AWS credentials from the workspace (from aws-auth block; e.g. aws:access_key@cli, aws:irsa@cli).
@@ -250,6 +254,7 @@ Suite Initialization
     Set Suite Variable    ${AWS_REGION}    ${AWS_REGION}
     Set Suite Variable    ${CERT_EXPIRY_DAYS}    ${CERT_EXPIRY_DAYS}
     Set Suite Variable    ${AWS_ACCOUNT_ID}    ${AWS_ACCOUNT_ID}
+    Set Suite Variable    ${AWS_ACCOUNT_NAME}    ${AWS_ACCOUNT_NAME}
     Set Suite Variable    ${aws_credentials}    ${aws_credentials}
     # AWS credentials are provided by the platform from the aws-auth block (runwhen-local);
     # the runtime uses aws_utils to set up the auth environment (IRSA, access key, assume role, etc.).

--- a/codebundles/aws-c7n-acm-health/sli.robot
+++ b/codebundles/aws-c7n-acm-health/sli.robot
@@ -12,7 +12,7 @@ Library    CloudCustodian.Core
 Suite Setup    Suite Initialization
 
 *** Tasks ***
-Check for unused ACM certificates in AWS Region `${AWS_REGION}` in AWS account `${AWS_ACCOUNT_ID}`
+Check for unused ACM certificates in AWS Region `${AWS_REGION}` in AWS account `${AWS_ACCOUNT_NAME}`
     [Documentation]  Find unused ACM certificates
     [Tags]    aws    acm    certificate    security    data:config
     ${c7n_output}=    RW.CLI.Run Cli
@@ -23,7 +23,7 @@ Check for unused ACM certificates in AWS Region `${AWS_REGION}` in AWS account `
     ${unused_certificate_score}=    Evaluate    1 if int(${count.stdout}) <= int(${MAX_UNUSED_CERTIFICATES}) else 0
     Set Global Variable    ${unused_certificate_score}
 
-Check for Expiring ACM certificates in AWS Region `${AWS_REGION}` in AWS account `${AWS_ACCOUNT_ID}`
+Check for Expiring ACM certificates in AWS Region `${AWS_REGION}` in AWS account `${AWS_ACCOUNT_NAME}`
     [Documentation]  Find Expiring ACM certificates
     [Tags]    aws    acm    certificate    expiration    data:config
     CloudCustodian.Core.Generate Policy   
@@ -37,7 +37,7 @@ Check for Expiring ACM certificates in AWS Region `${AWS_REGION}` in AWS account
     ${expiring_certificate_score}=    Evaluate    1 if int(${count.stdout}) <= int(${MAX_EXPIRING_CERTIFICATES}) else 0
     Set Global Variable    ${expiring_certificate_score}
 
-Check for expired ACM certificates in AWS Region `${AWS_REGION}` in AWS account `${AWS_ACCOUNT_ID}`
+Check for expired ACM certificates in AWS Region `${AWS_REGION}` in AWS account `${AWS_ACCOUNT_NAME}`
     [Documentation]  Find expired ACM certificates
     [Tags]    aws    acm    certificate    expiration    data:config
     ${c7n_output}=    RW.CLI.Run Cli
@@ -48,7 +48,7 @@ Check for expired ACM certificates in AWS Region `${AWS_REGION}` in AWS account 
     ${expired_certificate_score}=    Evaluate    1 if int(${count.stdout}) <= int(${MAX_EXPIRED_CERTIFICATES}) else 0
     Set Global Variable    ${expired_certificate_score}
 
-Check for Failed Status ACM Certificates in AWS Region `${AWS_REGION}` in AWS Account `${AWS_ACCOUNT_ID}`
+Check for Failed Status ACM Certificates in AWS Region `${AWS_REGION}` in AWS Account `${AWS_ACCOUNT_NAME}`
     [Documentation]  Find failed status ACM certificates
     [Tags]    aws    acm    certificate    status    data:config
     ${c7n_output}=    RW.CLI.Run Cli
@@ -59,7 +59,7 @@ Check for Failed Status ACM Certificates in AWS Region `${AWS_REGION}` in AWS Ac
     ${failed_certificate_score}=    Evaluate    1 if int(${count.stdout}) <= int(${MAX_FAILED_CERTIFICATES}) else 0
     Set Global Variable    ${failed_certificate_score}
 
-Check for Pending Validation ACM Certificates in AWS Region `${AWS_REGION}` in AWS Account `${AWS_ACCOUNT_ID}`
+Check for Pending Validation ACM Certificates in AWS Region `${AWS_REGION}` in AWS Account `${AWS_ACCOUNT_NAME}`
     [Documentation]  Find pending validation ACM certificates
     [Tags]    aws    acm    certificate    validation    data:config
     ${c7n_output}=    RW.CLI.Run Cli
@@ -84,6 +84,10 @@ Suite Initialization
     ${AWS_ACCOUNT_ID}=    RW.Core.Import User Variable   AWS_ACCOUNT_ID
     ...    type=string
     ...    description=AWS Account ID
+    ...    pattern=\w*
+    ${AWS_ACCOUNT_NAME}=    RW.Core.Import User Variable   AWS_ACCOUNT_NAME
+    ...    type=string
+    ...    description=AWS Account Name
     ...    pattern=\w*
     ${aws_credentials}=    RW.Core.Import Secret    aws_credentials
     ...    type=string
@@ -128,6 +132,7 @@ Suite Initialization
     ${clean_workding_dir}=    RW.CLI.Run Cli    cmd=rm -rf ${OUTPUT_DIR}/aws-c7n-acm-health
     Set Suite Variable    ${AWS_REGION}    ${AWS_REGION}
     Set Suite Variable    ${AWS_ACCOUNT_ID}    ${AWS_ACCOUNT_ID}
+    Set Suite Variable    ${AWS_ACCOUNT_NAME}    ${AWS_ACCOUNT_NAME}
     Set Suite Variable    ${CERT_EXPIRY_DAYS}    ${CERT_EXPIRY_DAYS}
     Set Suite Variable    ${MAX_UNUSED_CERTIFICATES}    ${MAX_UNUSED_CERTIFICATES}
     Set Suite Variable    ${MAX_FAILED_CERTIFICATES}    ${MAX_FAILED_CERTIFICATES}

--- a/codebundles/aws-c7n-ebs-health/.runwhen/templates/aws-c7n-ebs-health-sli.yaml
+++ b/codebundles/aws-c7n-ebs-health/.runwhen/templates/aws-c7n-ebs-health-sli.yaml
@@ -31,6 +31,8 @@ spec:
       value: "{{match_resource.resource.region}}"
     - name: AWS_ACCOUNT_ID
       value: "{{match_resource.resource.account_id}}"
+    - name: AWS_ACCOUNT_NAME
+      value: "{{match_resource.account_name}}"
   secretsProvided:
     {% include "aws-auth.yaml" ignore missing %}
   alerts:

--- a/codebundles/aws-c7n-ebs-health/.runwhen/templates/aws-c7n-ebs-health-sli.yaml
+++ b/codebundles/aws-c7n-ebs-health/.runwhen/templates/aws-c7n-ebs-health-sli.yaml
@@ -11,7 +11,7 @@ spec:
   displayUnitsShort: ok
   locations:
       - {{default_location}}
-  description: Measures security and health of AWS EBS volumes in AWS region {{match_resource.resource.region}} and account {{match_resource.resource.account_id}}
+  description: Measures security and health of AWS EBS volumes in AWS region {{match_resource.resource.region}} and account {{match_resource.account_name}}
   codeBundle:
     {% if repo_url %}
     repoUrl: {{repo_url}}

--- a/codebundles/aws-c7n-ebs-health/.runwhen/templates/aws-c7n-ebs-health-slx.yaml
+++ b/codebundles/aws-c7n-ebs-health/.runwhen/templates/aws-c7n-ebs-health-slx.yaml
@@ -8,8 +8,8 @@ metadata:
     {% include "common-annotations.yaml" %}
 spec:
   imageURL: https://storage.googleapis.com/runwhen-nonprod-shared-images/icons/aws/Resource-Icons_06072024/Res_Storage/Res_Amazon-Elastic-Block-Store_Multiple-Volumes_48.png
-  alias: AWS EBS Health For Region {{match_resource.resource.region}} in Account {{match_resource.resource.account_id}}
-  asMeasuredBy: The number of AWS EBS volumes and snapshots in region {{match_resource.resource.region}} and account {{match_resource.resource.account_id}}
+  alias: AWS EBS Health For Region {{match_resource.resource.region}} in Account {{match_resource.account_name}}
+  asMeasuredBy: The number of AWS EBS volumes and snapshots in region {{match_resource.resource.region}} and account {{match_resource.account_name}}
   configProvided:
   - name: SLX_PLACEHOLDER
     value: SLX_PLACEHOLDER

--- a/codebundles/aws-c7n-ebs-health/.runwhen/templates/aws-c7n-ebs-health-taskset.yaml
+++ b/codebundles/aws-c7n-ebs-health/.runwhen/templates/aws-c7n-ebs-health-taskset.yaml
@@ -26,5 +26,7 @@ spec:
       value: "{{match_resource.resource.region}}"
     - name: AWS_ACCOUNT_ID
       value: "{{match_resource.resource.account_id}}"
+    - name: AWS_ACCOUNT_NAME
+      value: "{{match_resource.account_name}}"
   secretsProvided:
     {% include "aws-auth.yaml" ignore missing %}

--- a/codebundles/aws-c7n-ebs-health/runbook.robot
+++ b/codebundles/aws-c7n-ebs-health/runbook.robot
@@ -14,7 +14,7 @@ Suite Setup    Suite Initialization
 
 
 *** Tasks ***
-List Unattached EBS Volumes in AWS Region `${AWS_REGION}` in AWS account `${AWS_ACCOUNT_ID}` 
+List Unattached EBS Volumes in AWS Region `${AWS_REGION}` in AWS account `${AWS_ACCOUNT_NAME}` 
     [Documentation]  Check for unattached EBS volumes in the specified region. 
     [Tags]    ebs    storage    aws    volume    unattached    data:config
     ${c7n_output}=    RW.CLI.Run Cli
@@ -51,7 +51,7 @@ List Unattached EBS Volumes in AWS Region `${AWS_REGION}` in AWS account `${AWS_
     END
 
 
-List Unencrypted EBS Volumes in AWS Region `${AWS_REGION}` in AWS account `${AWS_ACCOUNT_ID}`
+List Unencrypted EBS Volumes in AWS Region `${AWS_REGION}` in AWS account `${AWS_ACCOUNT_NAME}`
     [Documentation]  Check for Unencrypted EBS Volumes in the specified region. 
     [Tags]    ebs    storage    aws    volume    encryption    data:config
     ${c7n_output}=    RW.CLI.Run Cli
@@ -88,7 +88,7 @@ List Unencrypted EBS Volumes in AWS Region `${AWS_REGION}` in AWS account `${AWS
     END
 
 
-List Unused EBS Snapshots in AWS Region `${AWS_REGION}` in AWS account `${AWS_ACCOUNT_ID}`
+List Unused EBS Snapshots in AWS Region `${AWS_REGION}` in AWS account `${AWS_ACCOUNT_NAME}`
     [Documentation]  Check for Unused EBS Snapshots in the specified region. 
     [Tags]    ebs    storage    aws    volume    unused    data:config
     ${c7n_output}=    RW.CLI.Run Cli
@@ -134,6 +134,10 @@ Suite Initialization
     ...    type=string
     ...    description=AWS Account ID
     ...    pattern=\w*
+    ${AWS_ACCOUNT_NAME}=    RW.Core.Import User Variable   AWS_ACCOUNT_NAME
+    ...    type=string
+    ...    description=AWS Account Name
+    ...    pattern=\w*
     ${aws_credentials}=    RW.Core.Import Secret    aws_credentials
     ...    type=string
     ...    description=AWS credentials from the workspace (from aws-auth block; e.g. aws:access_key@cli, aws:irsa@cli).
@@ -141,6 +145,7 @@ Suite Initialization
     ${clean_workding_dir}=    RW.CLI.Run Cli    cmd=rm -rf ${OUTPUT_DIR}/aws-c7n-ebs-health         # Note: Clean out the cloud custoding report dir to ensure accurate data
     Set Suite Variable    ${AWS_REGION}    ${AWS_REGION}
     Set Suite Variable    ${AWS_ACCOUNT_ID}    ${AWS_ACCOUNT_ID}
+    Set Suite Variable    ${AWS_ACCOUNT_NAME}    ${AWS_ACCOUNT_NAME}
     Set Suite Variable    ${aws_credentials}    ${aws_credentials}
     # AWS credentials are provided by the platform from the aws-auth block (runwhen-local);
     # the runtime uses aws_utils to set up the auth environment (IRSA, access key, assume role, etc.).

--- a/codebundles/aws-c7n-ebs-health/runbook.robot
+++ b/codebundles/aws-c7n-ebs-health/runbook.robot
@@ -138,10 +138,7 @@ Suite Initialization
     ...    type=string
     ...    description=AWS credentials from the workspace (from aws-auth block; e.g. aws:access_key@cli, aws:irsa@cli).
     ...    pattern=\w*
-    ${aws_account_name_query}=       RW.CLI.Run Cli    
-    ...    cmd=aws organizations describe-account --account-id $(aws sts get-caller-identity --query 'Account' --output text) --query "Account.Name" --output text | tr -d '\n'
     ${clean_workding_dir}=    RW.CLI.Run Cli    cmd=rm -rf ${OUTPUT_DIR}/aws-c7n-ebs-health         # Note: Clean out the cloud custoding report dir to ensure accurate data
-    Set Suite Variable    ${AWS_ACCOUNT_NAME}    ${aws_account_name_query.stdout}
     Set Suite Variable    ${AWS_REGION}    ${AWS_REGION}
     Set Suite Variable    ${AWS_ACCOUNT_ID}    ${AWS_ACCOUNT_ID}
     Set Suite Variable    ${aws_credentials}    ${aws_credentials}

--- a/codebundles/aws-c7n-ebs-health/sli.robot
+++ b/codebundles/aws-c7n-ebs-health/sli.robot
@@ -61,6 +61,10 @@ Suite Initialization
     ...    type=string
     ...    description=AWS Account ID
     ...    pattern=\w*
+    ${AWS_ACCOUNT_NAME}=    RW.Core.Import User Variable   AWS_ACCOUNT_NAME
+    ...    type=string
+    ...    description=AWS Account Name
+    ...    pattern=\w*
     ${aws_credentials}=    RW.Core.Import Secret    aws_credentials
     ...    type=string
     ...    description=AWS credentials from the workspace (from aws-auth block; e.g. aws:access_key@cli, aws:irsa@cli).
@@ -80,6 +84,7 @@ Suite Initialization
     ${clean_workding_dir}=    RW.CLI.Run Cli    cmd=rm -rf ${OUTPUT_DIR}/aws-c7n-ebs-health         # Note: Clean out the cloud custoding report dir to ensure accurate data
     Set Suite Variable    ${AWS_REGION}    ${AWS_REGION}
     Set Suite Variable    ${AWS_ACCOUNT_ID}    ${AWS_ACCOUNT_ID}
+    Set Suite Variable    ${AWS_ACCOUNT_NAME}    ${AWS_ACCOUNT_NAME}
     Set Suite Variable    ${EVENT_THRESHOLD}    ${EVENT_THRESHOLD}
     Set Suite Variable    ${SECURITY_EVENT_THRESHOLD}    ${SECURITY_EVENT_THRESHOLD}
     Set Suite Variable    ${aws_credentials}    ${aws_credentials}

--- a/codebundles/aws-c7n-ec2-health/.runwhen/templates/aws-c7n-ec2-health-sli.yaml
+++ b/codebundles/aws-c7n-ec2-health/.runwhen/templates/aws-c7n-ec2-health-sli.yaml
@@ -11,7 +11,7 @@ spec:
   displayUnitsShort: ok
   locations:
       - {{default_location}}
-  description: Count the number of EC2 instances that are stale or stopped in this AWS region {{match_resource.resource.region}} and account {{match_resource.resource.account_id}}
+  description: Count the number of EC2 instances that are stale or stopped in this AWS region {{match_resource.resource.region}} and account {{match_resource.account_name}}
   codeBundle:
     {% if repo_url %}
     repoUrl: {{repo_url}}

--- a/codebundles/aws-c7n-ec2-health/.runwhen/templates/aws-c7n-ec2-health-sli.yaml
+++ b/codebundles/aws-c7n-ec2-health/.runwhen/templates/aws-c7n-ec2-health-sli.yaml
@@ -31,6 +31,8 @@ spec:
       value: "{{match_resource.resource.region}}"
     - name: AWS_ACCOUNT_ID
       value: "{{match_resource.resource.account_id}}"
+    - name: AWS_ACCOUNT_NAME
+      value: "{{match_resource.account_name}}"
     - name: AWS_EC2_AGE
       value: '60'
     - name: AWS_EC2_TAGS

--- a/codebundles/aws-c7n-ec2-health/.runwhen/templates/aws-c7n-ec2-health-slx.yaml
+++ b/codebundles/aws-c7n-ec2-health/.runwhen/templates/aws-c7n-ec2-health-slx.yaml
@@ -8,14 +8,14 @@ metadata:
     {% include "common-annotations.yaml" %}
 spec:
   imageURL: https://storage.googleapis.com/runwhen-nonprod-shared-images/icons/aws/Resource-Icons_06072024/Res_Compute/Res_Amazon-EC2_Instances_48.svg
-  alias: AWS EC2 Health For Region {{match_resource.resource.region}} in Account {{match_resource.resource.account_id}}
-  asMeasuredBy: The number of stale and stopped EC2 instances in region {{match_resource.resource.region}} and account {{match_resource.resource.account_id}}
+  alias: AWS EC2 Health For Region {{match_resource.resource.region}} in Account {{match_resource.account_name}}
+  asMeasuredBy: The number of stale and stopped EC2 instances in region {{match_resource.resource.region}} and account {{match_resource.account_name}}
   configProvided:
   - name: SLX_PLACEHOLDER
     value: SLX_PLACEHOLDER
   owners:
   - {{workspace.owner_email}}
-  statement: Identify stale and stopped EC2 instances that may pose security risks due to missed updates or inactivity in the region {{match_resource.resource.region}} and account {{match_resource.resource.account_id}}
+  statement: Identify stale and stopped EC2 instances that may pose security risks due to missed updates or inactivity in the region {{match_resource.resource.region}} and account {{match_resource.account_name}}
   additionalContext:
     {% include "aws-hierarchy.yaml" ignore missing %}
     qualified_name: "{{ match_resource.qualified_name | replace(":", "_") }}"

--- a/codebundles/aws-c7n-ec2-health/.runwhen/templates/aws-c7n-ec2-health-taskset.yaml
+++ b/codebundles/aws-c7n-ec2-health/.runwhen/templates/aws-c7n-ec2-health-taskset.yaml
@@ -26,6 +26,8 @@ spec:
       value: "{{match_resource.resource.region}}"
     - name: AWS_ACCOUNT_ID
       value: "{{match_resource.resource.account_id}}"
+    - name: AWS_ACCOUNT_NAME
+      value: "{{match_resource.account_name}}"
     - name: AWS_EC2_AGE
       value: '60'
     - name: AWS_EC2_TAGS

--- a/codebundles/aws-c7n-ec2-health/runbook.robot
+++ b/codebundles/aws-c7n-ec2-health/runbook.robot
@@ -13,7 +13,7 @@ Suite Setup    Suite Initialization
 
 
 *** Tasks ***
-List stale AWS EC2 instances in AWS Region `${AWS_REGION}` in AWS account `${AWS_ACCOUNT_ID}` 
+List stale AWS EC2 instances in AWS Region `${AWS_REGION}` in AWS account `${AWS_ACCOUNT_NAME}` 
     [Documentation]  List stale EC2 instances in AWS Region. 
     [Tags]    ec2    instance    aws    compute    stale    data:config
 
@@ -65,7 +65,7 @@ List stale AWS EC2 instances in AWS Region `${AWS_REGION}` in AWS account `${AWS
         RW.Core.Add Pre To Report     ${ec2_instances_list_length} stale instances found, below threshold of ${MAX_ALLOWED_STALE_INSTANCES}\n${report_data.stdout}
     END
 
-List stopped AWS EC2 instances in AWS Region `${AWS_REGION}` in AWS account `${AWS_ACCOUNT_ID}` 
+List stopped AWS EC2 instances in AWS Region `${AWS_REGION}` in AWS account `${AWS_ACCOUNT_NAME}` 
     [Documentation]  List stopped EC2 instances in AWS Region. 
     [Tags]    ec2    instance    aws    compute    data:config
     
@@ -118,7 +118,7 @@ List stopped AWS EC2 instances in AWS Region `${AWS_REGION}` in AWS account `${A
         RW.Core.Add Pre To Report    ${ec2_instances_list_length} stopped instances found, below threshold of ${MAX_ALLOWED_STOPPED_INSTANCES}\n${report_data.stdout}
     END
 
-List invalid AWS Auto Scaling Groups in AWS Region ${AWS_REGION} in AWS account ${AWS_ACCOUNT_ID}
+List invalid AWS Auto Scaling Groups in AWS Region ${AWS_REGION} in AWS account ${AWS_ACCOUNT_NAME}
     [Documentation]  List invalid Auto Scaling Groups
     [Tags]    asg    aws    compute    asg    data:config
 
@@ -197,6 +197,10 @@ Suite Initialization
     ...    type=string
     ...    description=AWS Account ID
     ...    pattern=\w*
+    ${AWS_ACCOUNT_NAME}=    RW.Core.Import User Variable   AWS_ACCOUNT_NAME
+    ...    type=string
+    ...    description=AWS Account Name
+    ...    pattern=\w*
     ${aws_credentials}=    RW.Core.Import Secret    aws_credentials
     ...    type=string
     ...    description=AWS credentials from the workspace (from aws-auth block; e.g. aws:access_key@cli, aws:irsa@cli).
@@ -236,6 +240,7 @@ Suite Initialization
     Set Suite Variable    ${AWS_EC2_TAGS}    ${AWS_EC2_TAGS}
     Set Suite Variable    ${AWS_REGION}    ${AWS_REGION}
     Set Suite Variable    ${AWS_ACCOUNT_ID}    ${AWS_ACCOUNT_ID}
+    Set Suite Variable    ${AWS_ACCOUNT_NAME}    ${AWS_ACCOUNT_NAME}
     Set Suite Variable    ${MAX_ALLOWED_STOPPED_INSTANCES}    ${MAX_ALLOWED_STOPPED_INSTANCES}
     Set Suite Variable    ${MAX_ALLOWED_STALE_INSTANCES}    ${MAX_ALLOWED_STALE_INSTANCES}
     Set Suite Variable    ${MAX_ALLOWED_INVALID_ASG}    ${MAX_ALLOWED_INVALID_ASG}

--- a/codebundles/aws-c7n-ec2-health/sli.robot
+++ b/codebundles/aws-c7n-ec2-health/sli.robot
@@ -13,7 +13,7 @@ Suite Setup    Suite Initialization
 
 
 *** Tasks ***
-Check for stale AWS EC2 instances in AWS Region `${AWS_REGION}` in AWS account `${AWS_ACCOUNT_ID}` 
+Check for stale AWS EC2 instances in AWS Region `${AWS_REGION}` in AWS account `${AWS_ACCOUNT_NAME}` 
     [Documentation]  Check for stale EC2 instances in AWS Region. 
     [Tags]    ec2    instance    aws    compute    data:config
     ${result}=    CloudCustodian.Core.Generate Policy   
@@ -28,7 +28,7 @@ Check for stale AWS EC2 instances in AWS Region `${AWS_REGION}` in AWS account `
     ${stale_ec2_instances_score}=    Evaluate    1 if int(${count.stdout}) <= int(${MAX_ALLOWED_STALE_INSTANCES}) else 0
     Set Global Variable    ${stale_ec2_instances_score}
 
-Check for stopped AWS EC2 instances in AWS Region `${AWS_REGION}` in AWS account `${AWS_ACCOUNT_ID}` 
+Check for stopped AWS EC2 instances in AWS Region `${AWS_REGION}` in AWS account `${AWS_ACCOUNT_NAME}` 
     [Documentation]  Check for stopped EC2 instances in AWS Region. 
     [Tags]    ec2    instance    aws    compute    data:config
     ${result}=    CloudCustodian.Core.Generate Policy   
@@ -43,7 +43,7 @@ Check for stopped AWS EC2 instances in AWS Region `${AWS_REGION}` in AWS account
     ${stopped_ec2_instances_score}=    Evaluate    1 if int(${count.stdout}) <= int(${MAX_ALLOWED_STOPPED_INSTANCES}) else 0
     Set Global Variable    ${stopped_ec2_instances_score}
 
-Check for invalid AWS Auto Scaling Groups in AWS Region `${AWS_REGION}` in AWS account `${AWS_ACCOUNT_ID}`
+Check for invalid AWS Auto Scaling Groups in AWS Region `${AWS_REGION}` in AWS account `${AWS_ACCOUNT_NAME}`
     [Documentation]  Check for invalid Auto Scaling Groups.
     [Tags]    asg    aws    compute    data:config
     ${c7n_output}=    RW.CLI.Run Cli
@@ -68,6 +68,10 @@ Suite Initialization
     ${AWS_ACCOUNT_ID}=    RW.Core.Import User Variable   AWS_ACCOUNT_ID
     ...    type=string
     ...    description=AWS Account ID
+    ...    pattern=\w*
+    ${AWS_ACCOUNT_NAME}=    RW.Core.Import User Variable   AWS_ACCOUNT_NAME
+    ...    type=string
+    ...    description=AWS Account Name
     ...    pattern=\w*
     ${aws_credentials}=    RW.Core.Import Secret    aws_credentials
     ...    type=string
@@ -108,6 +112,7 @@ Suite Initialization
     Set Suite Variable    ${AWS_EC2_TAGS}    ${AWS_EC2_TAGS}
     Set Suite Variable    ${AWS_REGION}    ${AWS_REGION}
     Set Suite Variable    ${AWS_ACCOUNT_ID}    ${AWS_ACCOUNT_ID}
+    Set Suite Variable    ${AWS_ACCOUNT_NAME}    ${AWS_ACCOUNT_NAME}
     Set Suite Variable    ${MAX_ALLOWED_STOPPED_INSTANCES}    ${MAX_ALLOWED_STOPPED_INSTANCES}
     Set Suite Variable    ${MAX_ALLOWED_STALE_INSTANCES}    ${MAX_ALLOWED_STALE_INSTANCES}
     Set Suite Variable    ${MAX_ALLOWED_INVALID_ASG}    ${MAX_ALLOWED_INVALID_ASG}

--- a/codebundles/aws-c7n-monitoring-health/.runwhen/templates/aws-c7n-monitoring-health-sli.yaml
+++ b/codebundles/aws-c7n-monitoring-health/.runwhen/templates/aws-c7n-monitoring-health-sli.yaml
@@ -31,6 +31,8 @@ spec:
       value: "{{match_resource.resource.region}}"
     - name: AWS_ACCOUNT_ID
       value: "{{match_resource.resource.account_id}}"
+    - name: AWS_ACCOUNT_NAME
+      value: "{{match_resource.account_name}}"
   secretsProvided:
     {% include "aws-auth.yaml" ignore missing %}
   alerts:

--- a/codebundles/aws-c7n-monitoring-health/.runwhen/templates/aws-c7n-monitoring-health-sli.yaml
+++ b/codebundles/aws-c7n-monitoring-health/.runwhen/templates/aws-c7n-monitoring-health-sli.yaml
@@ -11,7 +11,7 @@ spec:
   displayUnitsShort: ok
   locations:
       - {{default_location}}
-  description: Score AWS Monitoring Health (1 = Healthy, 0 = Unhealthy) by identifying CloudWatch Log Groups without retention period, Cloudtrail that is not multi-region and CloudTrail Trails without CloudWatch Logs in AWS region {{match_resource.resource.region}} and account {{match_resource.resource.account_id}}
+  description: Score AWS Monitoring Health (1 = Healthy, 0 = Unhealthy) by identifying CloudWatch Log Groups without retention period, Cloudtrail that is not multi-region and CloudTrail Trails without CloudWatch Logs in AWS region {{match_resource.resource.region}} and account {{match_resource.account_name}}
   codeBundle:
     {% if repo_url %}
     repoUrl: {{repo_url}}

--- a/codebundles/aws-c7n-monitoring-health/.runwhen/templates/aws-c7n-monitoring-health-slx.yaml
+++ b/codebundles/aws-c7n-monitoring-health/.runwhen/templates/aws-c7n-monitoring-health-slx.yaml
@@ -8,14 +8,14 @@ metadata:
     {% include "common-annotations.yaml" %}
 spec:
   imageURL: https://storage.googleapis.com/runwhen-nonprod-shared-images/icons/aws/Resource-Icons_06072024/Res_Management-Governance/Res_Amazon-CloudWatch_Logs_48.svg
-  alias: AWS CloudWatch Log Health For Region {{match_resource.resource.region}} in Account {{match_resource.resource.account_id}}
-  asMeasuredBy: CloudWatch Log Groups without retention period, Cloudtrail that is not multi-region and CloudTrail Trails without CloudWatch Logs in AWS region {{match_resource.resource.region}} and account {{match_resource.resource.account_id}}
+  alias: AWS CloudWatch Log Health For Region {{match_resource.resource.region}} in Account {{match_resource.account_name}}
+  asMeasuredBy: CloudWatch Log Groups without retention period, Cloudtrail that is not multi-region and CloudTrail Trails without CloudWatch Logs in AWS region {{match_resource.resource.region}} and account {{match_resource.account_name}}
   configProvided:
   - name: SLX_PLACEHOLDER
     value: SLX_PLACEHOLDER
   owners:
   - {{workspace.owner_email}}
-  statement: Identify CloudWatch and CloudTrail configuration or health issues in AWS region {{match_resource.resource.region}} and account {{match_resource.resource.account_id}}
+  statement: Identify CloudWatch and CloudTrail configuration or health issues in AWS region {{match_resource.resource.region}} and account {{match_resource.account_name}}
   additionalContext:
     {% include "aws-hierarchy.yaml" ignore missing %}
     qualified_name: "{{ match_resource.qualified_name | replace(":", "_") }}"

--- a/codebundles/aws-c7n-monitoring-health/.runwhen/templates/aws-c7n-monitoring-health-taskset.yaml
+++ b/codebundles/aws-c7n-monitoring-health/.runwhen/templates/aws-c7n-monitoring-health-taskset.yaml
@@ -8,7 +8,7 @@ metadata:
     {% include "common-annotations.yaml" %}
 spec:
   location: {{default_location}}
-  description: List AWS CloudWatch Log Groups without retention period, Cloudtrail that is not multi-region and CloudTrail Trails without CloudWatch Logs in AWS region {{match_resource.resource.region}} and account {{match_resource.resource.account_id}}
+  description: List AWS CloudWatch Log Groups without retention period, Cloudtrail that is not multi-region and CloudTrail Trails without CloudWatch Logs in AWS region {{match_resource.resource.region}} and account {{match_resource.account_name}}
   codeBundle:
     {% if repo_url %}
     repoUrl: {{repo_url}}

--- a/codebundles/aws-c7n-monitoring-health/.runwhen/templates/aws-c7n-monitoring-health-taskset.yaml
+++ b/codebundles/aws-c7n-monitoring-health/.runwhen/templates/aws-c7n-monitoring-health-taskset.yaml
@@ -26,5 +26,7 @@ spec:
       value: "{{match_resource.resource.region}}"
     - name: AWS_ACCOUNT_ID
       value: "{{match_resource.resource.account_id}}"
+    - name: AWS_ACCOUNT_NAME
+      value: "{{match_resource.account_name}}"
   secretsProvided:
     {% include "aws-auth.yaml" ignore missing %}

--- a/codebundles/aws-c7n-monitoring-health/runbook.robot
+++ b/codebundles/aws-c7n-monitoring-health/runbook.robot
@@ -12,7 +12,7 @@ Library    CloudCustodian.Core
 Suite Setup    Suite Initialization
 
 *** Tasks ***
-List CloudWatch Log Groups Without Retention Period in AWS Region `${AWS_REGION}` in AWS Account `${AWS_ACCOUNT_ID}`
+List CloudWatch Log Groups Without Retention Period in AWS Region `${AWS_REGION}` in AWS Account `${AWS_ACCOUNT_NAME}`
     [Documentation]  List CloudWatch Log Groups Without Retention Period
     [Tags]    aws    cloudwatch    logs    data:config
     ${c7n_output}=    RW.CLI.Run Cli
@@ -51,7 +51,7 @@ List CloudWatch Log Groups Without Retention Period in AWS Region `${AWS_REGION}
         RW.Core.Add Pre To Report    "No CloudWatch Log Groups without retention period found in AWS Region `${AWS_REGION}` in AWS Account `${AWS_ACCOUNT_ID}`"
     END
 
-Check CloudTrail Configuration in AWS Region `${AWS_REGION}` in AWS Account `${AWS_ACCOUNT_ID}`
+Check CloudTrail Configuration in AWS Region `${AWS_REGION}` in AWS Account `${AWS_ACCOUNT_NAME}`
     [Documentation]    Check if CloudTrail exists and is configured for multi-region
     [Tags]    aws    cloudtrail    data:config
     ${c7n_output}=    RW.CLI.Run Cli
@@ -115,7 +115,7 @@ Check CloudTrail Configuration in AWS Region `${AWS_REGION}` in AWS Account `${A
         END
     END
 
- Check for CloudTrail integration with CloudWatch Logs in AWS Region `${AWS_REGION}` in AWS Account `${AWS_ACCOUNT_ID}`
+ Check for CloudTrail integration with CloudWatch Logs in AWS Region `${AWS_REGION}` in AWS Account `${AWS_ACCOUNT_NAME}`
     [Documentation]    Check for CloudTrail integration with CloudWatch Logs
     [Tags]    aws    cloudtrail    cloudwatch    logs    data:config
     ${c7n_output}=    RW.CLI.Run Cli
@@ -160,6 +160,10 @@ Suite Initialization
     ...    type=string
     ...    description=AWS Account ID
     ...    pattern=\w*
+    ${AWS_ACCOUNT_NAME}=    RW.Core.Import User Variable   AWS_ACCOUNT_NAME
+    ...    type=string
+    ...    description=AWS Account Name
+    ...    pattern=\w*
     ${aws_credentials}=    RW.Core.Import Secret    aws_credentials
     ...    type=string
     ...    description=AWS credentials from the workspace (from aws-auth block; e.g. aws:access_key@cli, aws:irsa@cli).
@@ -167,6 +171,7 @@ Suite Initialization
     ${clean_workding_dir}=    RW.CLI.Run Cli    cmd=rm -rf ${OUTPUT_DIR}/aws-c7n-monitoring-health
     Set Suite Variable    ${AWS_REGION}    ${AWS_REGION}
     Set Suite Variable    ${AWS_ACCOUNT_ID}    ${AWS_ACCOUNT_ID}
+    Set Suite Variable    ${AWS_ACCOUNT_NAME}    ${AWS_ACCOUNT_NAME}
     Set Suite Variable    ${aws_credentials}    ${aws_credentials}
     # AWS credentials are provided by the platform from the aws-auth block (runwhen-local);
     # the runtime uses aws_utils to set up the auth environment (IRSA, access key, assume role, etc.).

--- a/codebundles/aws-c7n-monitoring-health/sli.robot
+++ b/codebundles/aws-c7n-monitoring-health/sli.robot
@@ -12,7 +12,7 @@ Library    CloudCustodian.Core
 Suite Setup    Suite Initialization
 
 *** Tasks ***
-Check CloudWatch Log Groups Without Retention Period in AWS Region `${AWS_REGION}` in AWS account `${AWS_ACCOUNT_ID}`
+Check CloudWatch Log Groups Without Retention Period in AWS Region `${AWS_REGION}` in AWS account `${AWS_ACCOUNT_NAME}`
     [Documentation]  Check CloudWatch Log Groups without retention period
     [Tags]    aws    cloudwatch    logs    data:config
     ${c7n_output}=    RW.CLI.Run Cli
@@ -23,7 +23,7 @@ Check CloudWatch Log Groups Without Retention Period in AWS Region `${AWS_REGION
     ${no_retention_score}=    Evaluate    1 if int(${count.stdout}) <= int(${MAX_LOG_GROUPS_ALLOWED}) else 0
     Set Global Variable    ${no_retention_score}
 
-Check if CloudTrail exists and is configured for multi-region in AWS Region `${AWS_REGION}` in AWS Account `${AWS_ACCOUNT_ID}`
+Check if CloudTrail exists and is configured for multi-region in AWS Region `${AWS_REGION}` in AWS Account `${AWS_ACCOUNT_NAME}`
     [Documentation]    Check if CloudTrail exists and is configured for multi-region
     [Tags]    aws    cloudtrail    logs    data:config
     ${c7n_output}=    RW.CLI.Run Cli
@@ -65,8 +65,8 @@ Check if CloudTrail exists and is configured for multi-region in AWS Region `${A
         Set Global Variable    ${cloudtrail_score}
     END
 
-Check CloudTrail Without CloudWatch Logs in AWS Region `${AWS_REGION}` in AWS Account `${AWS_ACCOUNT_ID}`
-    [Documentation]    Check if CloudTrail exists and is configured for multi-region in AWS Region `${AWS_REGION}` in AWS Account `${AWS_ACCOUNT_ID}`
+Check CloudTrail Without CloudWatch Logs in AWS Region `${AWS_REGION}` in AWS Account `${AWS_ACCOUNT_NAME}`
+    [Documentation]    Check if CloudTrail exists and is configured for multi-region in AWS Region `${AWS_REGION}` in AWS Account `${AWS_ACCOUNT_NAME}`
     [Tags]    aws    cloudtrail    cloudwatch    logs    data:config
     ${c7n_output}=    RW.CLI.Run Cli
     ...    cmd=custodian run -r ${AWS_REGION} --output-dir ${OUTPUT_DIR}/aws-c7n-monitoring-health ${CURDIR}/trail-without-cloudwatch-logs.yaml --cache-period 0
@@ -100,6 +100,10 @@ Suite Initialization
     ...    type=string
     ...    description=AWS Account ID
     ...    pattern=\w*
+    ${AWS_ACCOUNT_NAME}=    RW.Core.Import User Variable   AWS_ACCOUNT_NAME
+    ...    type=string
+    ...    description=AWS Account Name
+    ...    pattern=\w*
     ${aws_credentials}=    RW.Core.Import Secret    aws_credentials
     ...    type=string
     ...    description=AWS credentials from the workspace (from aws-auth block; e.g. aws:access_key@cli, aws:irsa@cli).
@@ -125,6 +129,7 @@ Suite Initialization
     ${clean_workding_dir}=    RW.CLI.Run Cli    cmd=rm -rf ${OUTPUT_DIR}/aws-c7n-monitoring-health
     Set Suite Variable    ${AWS_REGION}    ${AWS_REGION}
     Set Suite Variable    ${AWS_ACCOUNT_ID}    ${AWS_ACCOUNT_ID}
+    Set Suite Variable    ${AWS_ACCOUNT_NAME}    ${AWS_ACCOUNT_NAME}
     Set Suite Variable    ${MAX_LOG_GROUPS_ALLOWED}    ${MAX_LOG_GROUPS_ALLOWED}
     Set Suite Variable    ${MAX_CLOUDTRAIL_TRAILS_WITHOUT_CLOUDWATCH_LOGS_ALLOWED}    ${MAX_CLOUDTRAIL_TRAILS_WITHOUT_CLOUDWATCH_LOGS_ALLOWED}
     Set Suite Variable    ${aws_credentials}    ${aws_credentials}

--- a/codebundles/aws-c7n-network-health/.runwhen/templates/aws-c7n-network-health-sli.yaml
+++ b/codebundles/aws-c7n-network-health/.runwhen/templates/aws-c7n-network-health-sli.yaml
@@ -31,6 +31,8 @@ spec:
       value: "{{match_resource.resource.region}}"
     - name: AWS_ACCOUNT_ID
       value: "{{match_resource.resource.account_id}}"
+    - name: AWS_ACCOUNT_NAME
+      value: "{{match_resource.account_name}}"
   secretsProvided:
     {% include "aws-auth.yaml" ignore missing %}
   alerts:

--- a/codebundles/aws-c7n-network-health/.runwhen/templates/aws-c7n-network-health-sli.yaml
+++ b/codebundles/aws-c7n-network-health/.runwhen/templates/aws-c7n-network-health-sli.yaml
@@ -11,7 +11,7 @@ spec:
   displayUnitsShort: ok
   locations:
       - {{default_location}}
-  description: Score Network Health (1 = Healthy, 0 = Unhealty) by identifying publicly accessible security groups, unused Elastic IPs, unused ELBs, and VPCs with flow logs disabled in AWS account {{match_resource.resource.account_id}}
+  description: Score Network Health (1 = Healthy, 0 = Unhealty) by identifying publicly accessible security groups, unused Elastic IPs, unused ELBs, and VPCs with flow logs disabled in AWS account {{match_resource.account_name}}
   codeBundle:
     {% if repo_url %}
     repoUrl: {{repo_url}}

--- a/codebundles/aws-c7n-network-health/.runwhen/templates/aws-c7n-network-health-slx.yaml
+++ b/codebundles/aws-c7n-network-health/.runwhen/templates/aws-c7n-network-health-slx.yaml
@@ -8,14 +8,14 @@ metadata:
     {% include "common-annotations.yaml" %}
 spec:
   imageURL: https://storage.googleapis.com/runwhen-nonprod-shared-images/icons/aws/Resource-Icons_06072024/Res_Networking-Content-Delivery/Res_Amazon-VPC_Virtual-private-cloud-VPC_48.svg
-  alias: AWS Network Health For AWS Account {{match_resource.resource.account_id}}
-  asMeasuredBy: The number of publicly accessible security groups, unused EIPs, unused ELBs, and VPCs with flow logs disabled in AWS account {{match_resource.resource.account_id}}
+  alias: AWS Network Health For AWS Account {{match_resource.account_name}}
+  asMeasuredBy: The number of publicly accessible security groups, unused EIPs, unused ELBs, and VPCs with flow logs disabled in AWS account {{match_resource.account_name}}
   configProvided:
   - name: SLX_PLACEHOLDER
     value: SLX_PLACEHOLDER
   owners:
   - {{workspace.owner_email}}
-  statement: Identify publicly accessible security groups, unused EIPs, unused ELBs, and VPCs with flow logs disabled in the AWS account {{match_resource.resource.account_id}}
+  statement: Identify publicly accessible security groups, unused EIPs, unused ELBs, and VPCs with flow logs disabled in the AWS account {{match_resource.account_name}}
   additionalContext:
     {% include "aws-hierarchy.yaml" ignore missing %}
     qualified_name: "{{ match_resource.qualified_name | replace(":", "_") }}"

--- a/codebundles/aws-c7n-network-health/.runwhen/templates/aws-c7n-network-health-taskset.yaml
+++ b/codebundles/aws-c7n-network-health/.runwhen/templates/aws-c7n-network-health-taskset.yaml
@@ -8,7 +8,7 @@ metadata:
     {% include "common-annotations.yaml" %}
 spec:
   location: {{default_location}}
-  description: List publicly accessible security groups, unused EIPs, unused ELBs, and VPCs with flow logs disabled in the AWS account {{match_resource.resource.account_id}}
+  description: List publicly accessible security groups, unused EIPs, unused ELBs, and VPCs with flow logs disabled in the AWS account {{match_resource.account_name}}
   codeBundle:
     {% if repo_url %}
     repoUrl: {{repo_url}}

--- a/codebundles/aws-c7n-network-health/.runwhen/templates/aws-c7n-network-health-taskset.yaml
+++ b/codebundles/aws-c7n-network-health/.runwhen/templates/aws-c7n-network-health-taskset.yaml
@@ -26,5 +26,7 @@ spec:
       value: "{{match_resource.resource.region}}"
     - name: AWS_ACCOUNT_ID
       value: "{{match_resource.resource.account_id}}"
+    - name: AWS_ACCOUNT_NAME
+      value: "{{match_resource.account_name}}"
   secretsProvided:
     {% include "aws-auth.yaml" ignore missing %}

--- a/codebundles/aws-c7n-network-health/runbook.robot
+++ b/codebundles/aws-c7n-network-health/runbook.robot
@@ -13,7 +13,7 @@ Suite Setup    Suite Initialization
 
 
 *** Tasks ***
-List Publicly Accessible Security Groups in AWS account `${AWS_ACCOUNT_ID}` 
+List Publicly Accessible Security Groups in AWS account `${AWS_ACCOUNT_NAME}` 
     [Documentation]  Find publicly accessible security groups (e.g., "0.0.0.0/0" or "::/0")
     [Tags]    tag    aws    security-group    network    data:config
     CloudCustodian.Core.Generate Policy   
@@ -54,7 +54,7 @@ List Publicly Accessible Security Groups in AWS account `${AWS_ACCOUNT_ID}`
         END
     END
 
-List unused Elastic IPs in AWS account `${AWS_ACCOUNT_ID}`
+List unused Elastic IPs in AWS account `${AWS_ACCOUNT_NAME}`
     [Documentation]  Find unused Elastic IPs that are not associated with any instance or network interface
     [Tags]    aws    eip    network    data:config
     FOR    ${region}    IN    @{AWS_ENABLED_REGIONS}
@@ -94,7 +94,7 @@ List unused Elastic IPs in AWS account `${AWS_ACCOUNT_ID}`
         END
     END
 
-List unused ELBs in AWS account `${AWS_ACCOUNT_ID}`
+List unused ELBs in AWS account `${AWS_ACCOUNT_NAME}`
     [Documentation]  Find unused Application Load Balancers (ALBs) and Network Load Balancers (NLBs) that do not have any associated targets
     [Tags]    aws    elb    network    data:config
     FOR    ${region}    IN    @{AWS_ENABLED_REGIONS}
@@ -134,7 +134,7 @@ List unused ELBs in AWS account `${AWS_ACCOUNT_ID}`
         END
     END
 
-List VPCs with Flow Logs Disabled in AWS account `${AWS_ACCOUNT_ID}`
+List VPCs with Flow Logs Disabled in AWS account `${AWS_ACCOUNT_NAME}`
     [Documentation]  Find VPCs that do not have flow logs enabled
     [Tags]    aws    vpc    network    data:config
     CloudCustodian.Core.Generate Policy   
@@ -185,6 +185,10 @@ Suite Initialization
     ...    type=string
     ...    description=AWS Account ID
     ...    pattern=\w*
+    ${AWS_ACCOUNT_NAME}=    RW.Core.Import User Variable   AWS_ACCOUNT_NAME
+    ...    type=string
+    ...    description=AWS Account Name
+    ...    pattern=\w*
     ${aws_credentials}=    RW.Core.Import Secret    aws_credentials
     ...    type=string
     ...    description=AWS credentials from the workspace (from aws-auth block; e.g. aws:access_key@cli, aws:irsa@cli).
@@ -216,4 +220,5 @@ Suite Initialization
     Set Suite Variable    ${AWS_SECURITY_GROUP_TAGS}    ${AWS_SECURITY_GROUP_TAGS}
     Set Suite Variable    ${AWS_VPC_TAGS}    ${AWS_VPC_TAGS}
     Set Suite Variable    ${AWS_ACCOUNT_ID}    ${AWS_ACCOUNT_ID}
+    Set Suite Variable    ${AWS_ACCOUNT_NAME}    ${AWS_ACCOUNT_NAME}
     Set Suite Variable    ${aws_credentials}    ${aws_credentials}

--- a/codebundles/aws-c7n-network-health/sli.robot
+++ b/codebundles/aws-c7n-network-health/sli.robot
@@ -13,7 +13,7 @@ Suite Setup    Suite Initialization
 
 
 *** Tasks ***
-Check for publicly accessible security groups in AWS account `${AWS_ACCOUNT_ID}`
+Check for publicly accessible security groups in AWS account `${AWS_ACCOUNT_NAME}`
     [Documentation]  Find publicly accessible security groups (e.g., "0.0.0.0/0" or "::/0")
     [Tags]    aws    security-group    network    data:config
     CloudCustodian.Core.Generate Policy   
@@ -32,7 +32,7 @@ Check for publicly accessible security groups in AWS account `${AWS_ACCOUNT_ID}`
     Set Global Variable    ${public_ip_access_score}
 
 
-Check for unused Elastic IPs in AWS account `${AWS_ACCOUNT_ID}`
+Check for unused Elastic IPs in AWS account `${AWS_ACCOUNT_NAME}`
     [Documentation]  Find unused Elastic IPs that are not associated with any instance or network interface
     [Tags]    aws    eip    network    data:config
     ${total_count}=    Set Variable    0
@@ -47,7 +47,7 @@ Check for unused Elastic IPs in AWS account `${AWS_ACCOUNT_ID}`
     ${unattached_eip_score}=    Evaluate    1 if ${total_count} <= int(${MAX_ALLOWED_UNUSED_RESOURCES}) else 0
     Set Global Variable    ${unattached_eip_score}
 
-Check for unused ELBs in AWS account `${AWS_ACCOUNT_ID}`
+Check for unused ELBs in AWS account `${AWS_ACCOUNT_NAME}`
     [Documentation]  Find unused Application Load Balancers (ALBs) and Network Load Balancers (NLBs) that do not have any associated targets
     [Tags]    aws    elb    network    data:config
     ${total_count}=    Set Variable    0
@@ -62,7 +62,7 @@ Check for unused ELBs in AWS account `${AWS_ACCOUNT_ID}`
     ${unused_elb_score}=    Evaluate    1 if ${total_count} <= int(${MAX_ALLOWED_UNUSED_RESOURCES}) else 0
     Set Global Variable    ${unused_elb_score}
 
-Check for VPCs with Flow Logs disabled in AWS account `${AWS_ACCOUNT_ID}`
+Check for VPCs with Flow Logs disabled in AWS account `${AWS_ACCOUNT_NAME}`
     [Documentation]  Find VPCs that do not have Flow Logs enabled
     [Tags]    aws    vpc    network    data:config
     CloudCustodian.Core.Generate Policy   
@@ -94,6 +94,10 @@ Suite Initialization
     ${AWS_ACCOUNT_ID}=    RW.Core.Import User Variable   AWS_ACCOUNT_ID
     ...    type=string
     ...    description=AWS Account ID
+    ...    pattern=\w*
+    ${AWS_ACCOUNT_NAME}=    RW.Core.Import User Variable   AWS_ACCOUNT_NAME
+    ...    type=string
+    ...    description=AWS Account Name
     ...    pattern=\w*
     ${aws_credentials}=    RW.Core.Import Secret    aws_credentials
     ...    type=string
@@ -144,6 +148,7 @@ Suite Initialization
     Set Suite Variable    ${AWS_SECURITY_GROUP_TAGS}    ${AWS_SECURITY_GROUP_TAGS}
     Set Suite Variable    ${AWS_VPC_TAGS}    ${AWS_VPC_TAGS}
     Set Suite Variable    ${AWS_ACCOUNT_ID}    ${AWS_ACCOUNT_ID}
+    Set Suite Variable    ${AWS_ACCOUNT_NAME}    ${AWS_ACCOUNT_NAME}
     Set Suite Variable    ${UNSECURED_SG_THRESHOLD}    ${UNSECURED_SG_THRESHOLD}
     Set Suite Variable    ${aws_credentials}    ${aws_credentials}
     Set Suite Variable    ${DISABLED_FLOW_LOG_THRESHOLD}    ${DISABLED_FLOW_LOG_THRESHOLD}

--- a/codebundles/aws-c7n-rds-health/.runwhen/templates/aws-c7n-rds-health-sli.yaml
+++ b/codebundles/aws-c7n-rds-health/.runwhen/templates/aws-c7n-rds-health-sli.yaml
@@ -11,7 +11,7 @@ spec:
   displayUnitsShort: ok
   locations:
       - {{default_location}}
-  description: Score RDS Health (1 = Healthy, 0 = Unhealty) by identifying RDS instances that are unencrypted, publicly accessible, or have backups disabled in this AWS region {{match_resource.resource.region}} and account {{match_resource.resource.account_id}}
+  description: Score RDS Health (1 = Healthy, 0 = Unhealty) by identifying RDS instances that are unencrypted, publicly accessible, or have backups disabled in this AWS region {{match_resource.resource.region}} and account {{match_resource.account_name}}
   codeBundle:
     {% if repo_url %}
     repoUrl: {{repo_url}}

--- a/codebundles/aws-c7n-rds-health/.runwhen/templates/aws-c7n-rds-health-sli.yaml
+++ b/codebundles/aws-c7n-rds-health/.runwhen/templates/aws-c7n-rds-health-sli.yaml
@@ -31,6 +31,8 @@ spec:
       value: "{{match_resource.resource.region}}"
     - name: AWS_ACCOUNT_ID
       value: "{{match_resource.resource.account_id}}"
+    - name: AWS_ACCOUNT_NAME
+      value: "{{match_resource.account_name}}"
   secretsProvided:
     {% include "aws-auth.yaml" ignore missing %}
   alerts:

--- a/codebundles/aws-c7n-rds-health/.runwhen/templates/aws-c7n-rds-health-slx.yaml
+++ b/codebundles/aws-c7n-rds-health/.runwhen/templates/aws-c7n-rds-health-slx.yaml
@@ -8,8 +8,8 @@ metadata:
     {% include "common-annotations.yaml" %}
 spec:
   imageURL: https://storage.googleapis.com/runwhen-nonprod-shared-images/icons/aws/Resource-Icons_06072024/Res_Database/Res_Amazon-Aurora_Amazon-RDS-Instance_48.svg
-  alias: AWS RDS Health For Region {{match_resource.resource.region}} in Account {{match_resource.resource.account_id}}
-  asMeasuredBy: RDS instance configuration issues (unencrypted, publicly accessible, or have backups disabled) in region {{match_resource.resource.region}} and account {{match_resource.resource.account_id}}
+  alias: AWS RDS Health For Region {{match_resource.resource.region}} in Account {{match_resource.account_name}}
+  asMeasuredBy: RDS instance configuration issues (unencrypted, publicly accessible, or have backups disabled) in region {{match_resource.resource.region}} and account {{match_resource.account_name}}
   configProvided:
   - name: SLX_PLACEHOLDER
     value: SLX_PLACEHOLDER

--- a/codebundles/aws-c7n-rds-health/.runwhen/templates/aws-c7n-rds-health-taskset.yaml
+++ b/codebundles/aws-c7n-rds-health/.runwhen/templates/aws-c7n-rds-health-taskset.yaml
@@ -26,5 +26,7 @@ spec:
       value: "{{match_resource.resource.region}}"
     - name: AWS_ACCOUNT_ID
       value: "{{match_resource.resource.account_id}}"
+    - name: AWS_ACCOUNT_NAME
+      value: "{{match_resource.account_name}}"
   secretsProvided:
     {% include "aws-auth.yaml" ignore missing %}

--- a/codebundles/aws-c7n-rds-health/runbook.robot
+++ b/codebundles/aws-c7n-rds-health/runbook.robot
@@ -12,7 +12,7 @@ Library    CloudCustodian.Core
 Suite Setup    Suite Initialization
 
 *** Tasks ***
-List Unencrypted RDS Instances in AWS Region `${AWS_REGION}` in AWS Account `${AWS_ACCOUNT_ID}`
+List Unencrypted RDS Instances in AWS Region `${AWS_REGION}` in AWS Account `${AWS_ACCOUNT_NAME}`
     [Documentation]  Find unencrypted RDS instances
     [Tags]    aws    rds    database    encryption    data:config
     ${c7n_output}=    RW.CLI.Run Cli
@@ -49,7 +49,7 @@ List Unencrypted RDS Instances in AWS Region `${AWS_REGION}` in AWS Account `${A
     END
 
 
-List Publicly Accessible RDS Instances in AWS Region `${AWS_REGION}` in AWS Account `${AWS_ACCOUNT_ID}`
+List Publicly Accessible RDS Instances in AWS Region `${AWS_REGION}` in AWS Account `${AWS_ACCOUNT_NAME}`
     [Documentation]  Find publicly accessible RDS instances
     [Tags]    aws    rds    database    security    data:config
     ${c7n_output}=    RW.CLI.Run Cli
@@ -85,7 +85,7 @@ List Publicly Accessible RDS Instances in AWS Region `${AWS_REGION}` in AWS Acco
         END
     END
 
-List RDS Instances with Backups Disabled in AWS Region `${AWS_REGION}` in AWS Account `${AWS_ACCOUNT_ID}`
+List RDS Instances with Backups Disabled in AWS Region `${AWS_REGION}` in AWS Account `${AWS_ACCOUNT_NAME}`
     [Documentation]  Identify RDS instances with backups disabled
     [Tags]    aws    rds    database    backups    data:config
     ${c7n_output}=    RW.CLI.Run Cli
@@ -131,6 +131,10 @@ Suite Initialization
     ...    type=string
     ...    description=AWS Account ID
     ...    pattern=\w*
+    ${AWS_ACCOUNT_NAME}=    RW.Core.Import User Variable   AWS_ACCOUNT_NAME
+    ...    type=string
+    ...    description=AWS Account Name
+    ...    pattern=\w*
     ${aws_credentials}=    RW.Core.Import Secret    aws_credentials
     ...    type=string
     ...    description=AWS credentials from the workspace (from aws-auth block; e.g. aws:access_key@cli, aws:irsa@cli).
@@ -138,6 +142,7 @@ Suite Initialization
     ${clean_workding_dir}=    RW.CLI.Run Cli    cmd=rm -rf ${OUTPUT_DIR}/aws-c7n-rds-health
     Set Suite Variable    ${AWS_REGION}    ${AWS_REGION}
     Set Suite Variable    ${AWS_ACCOUNT_ID}    ${AWS_ACCOUNT_ID}
+    Set Suite Variable    ${AWS_ACCOUNT_NAME}    ${AWS_ACCOUNT_NAME}
     Set Suite Variable    ${aws_credentials}    ${aws_credentials}
     # AWS credentials are provided by the platform from the aws-auth block (runwhen-local);
     # the runtime uses aws_utils to set up the auth environment (IRSA, access key, assume role, etc.).

--- a/codebundles/aws-c7n-rds-health/sli.robot
+++ b/codebundles/aws-c7n-rds-health/sli.robot
@@ -12,7 +12,7 @@ Library    CloudCustodian.Core
 Suite Setup    Suite Initialization
 
 *** Tasks ***
-Check for unencrypted RDS instances in AWS Region `${AWS_REGION}` in AWS account `${AWS_ACCOUNT_ID}`
+Check for unencrypted RDS instances in AWS Region `${AWS_REGION}` in AWS account `${AWS_ACCOUNT_NAME}`
     [Documentation]  Find unencrypted RDS instances
     [Tags]    aws    rds    database    encryption    data:config
     ${c7n_output}=    RW.CLI.Run Cli
@@ -23,7 +23,7 @@ Check for unencrypted RDS instances in AWS Region `${AWS_REGION}` in AWS account
     ${unencrypted_rds_score}=    Evaluate    1 if int(${count.stdout}) <= int(${EVENT_THRESHOLD}) else 0
     Set Global Variable    ${unencrypted_rds_score}
 
-Check for publicly accessible RDS instances in AWS Region `${AWS_REGION}` in AWS account `${AWS_ACCOUNT_ID}`
+Check for publicly accessible RDS instances in AWS Region `${AWS_REGION}` in AWS account `${AWS_ACCOUNT_NAME}`
     [Documentation]  Find publicly accessible RDS instances
     [Tags]    aws    rds    database    security    data:config
     ${c7n_output}=    RW.CLI.Run Cli
@@ -34,7 +34,7 @@ Check for publicly accessible RDS instances in AWS Region `${AWS_REGION}` in AWS
     ${publicly_accessible_rds_score}=    Evaluate    1 if int(${count.stdout}) <= int(${EVENT_THRESHOLD}) else 0
     Set Global Variable    ${publicly_accessible_rds_score}
 
-Check for disabled backup RDS instances in AWS Region `${AWS_REGION}` in AWS account `${AWS_ACCOUNT_ID}`
+Check for disabled backup RDS instances in AWS Region `${AWS_REGION}` in AWS account `${AWS_ACCOUNT_NAME}`
     [Documentation]  Find RDS instances with backups disabled
     [Tags]    aws    rds    database    backups    data:config
     ${c7n_output}=    RW.CLI.Run Cli
@@ -62,6 +62,10 @@ Suite Initialization
     ...    type=string
     ...    description=AWS Account ID
     ...    pattern=\w*
+    ${AWS_ACCOUNT_NAME}=    RW.Core.Import User Variable   AWS_ACCOUNT_NAME
+    ...    type=string
+    ...    description=AWS Account Name
+    ...    pattern=\w*
     ${aws_credentials}=    RW.Core.Import Secret    aws_credentials
     ...    type=string
     ...    description=AWS credentials from the workspace (from aws-auth block; e.g. aws:access_key@cli, aws:irsa@cli).
@@ -75,6 +79,7 @@ Suite Initialization
     ${clean_workding_dir}=    RW.CLI.Run Cli    cmd=rm -rf ${OUTPUT_DIR}/aws-c7n-rds-health
     Set Suite Variable    ${AWS_REGION}    ${AWS_REGION}
     Set Suite Variable    ${AWS_ACCOUNT_ID}    ${AWS_ACCOUNT_ID}
+    Set Suite Variable    ${AWS_ACCOUNT_NAME}    ${AWS_ACCOUNT_NAME}
     Set Suite Variable    ${EVENT_THRESHOLD}    ${EVENT_THRESHOLD}
     Set Suite Variable    ${aws_credentials}    ${aws_credentials}
     # AWS credentials are provided by the platform from the aws-auth block (runwhen-local);

--- a/codebundles/aws-c7n-s3-health/.runwhen/templates/aws-c7n-s3-health-sli.yaml
+++ b/codebundles/aws-c7n-s3-health/.runwhen/templates/aws-c7n-s3-health-sli.yaml
@@ -31,5 +31,7 @@ spec:
       value: "{{match_resource.resource.region}}"
     - name: AWS_ACCOUNT_ID
       value: "{{match_resource.resource.account_id}}"
+    - name: AWS_ACCOUNT_NAME
+      value: "{{match_resource.account_name}}"
   secretsProvided:
     {% include "aws-auth.yaml" ignore missing %}

--- a/codebundles/aws-c7n-s3-health/.runwhen/templates/aws-c7n-s3-health-slx.yaml
+++ b/codebundles/aws-c7n-s3-health/.runwhen/templates/aws-c7n-s3-health-slx.yaml
@@ -8,8 +8,8 @@ metadata:
     {% include "common-annotations.yaml" %}
 spec:
   imageURL: https://storage.googleapis.com/runwhen-nonprod-shared-images/icons/aws/s3.png
-  alias: AWS S3 Bucket Health For Region {{match_resource.resource.region}}
-  asMeasuredBy: The number of AWS S3 Buckets in region {{match_resource.resource.region}}
+  alias: AWS S3 Bucket Health For Region {{match_resource.resource.region}} in Account {{match_resource.account_name}}
+  asMeasuredBy: The number of AWS S3 Buckets in region {{match_resource.resource.region}} and account {{match_resource.account_name}}
   configProvided:
   - name: SLX_PLACEHOLDER
     value: SLX_PLACEHOLDER

--- a/codebundles/aws-c7n-s3-health/.runwhen/templates/aws-c7n-s3-health-taskset.yaml
+++ b/codebundles/aws-c7n-s3-health/.runwhen/templates/aws-c7n-s3-health-taskset.yaml
@@ -26,5 +26,7 @@ spec:
       value: "{{match_resource.resource.region}}"
     - name: AWS_ACCOUNT_ID
       value: "{{match_resource.resource.account_id}}"
+    - name: AWS_ACCOUNT_NAME
+      value: "{{match_resource.account_name}}"
   secretsProvided:
     {% include "aws-auth.yaml" ignore missing %}

--- a/codebundles/aws-c7n-s3-health/runbook.robot
+++ b/codebundles/aws-c7n-s3-health/runbook.robot
@@ -60,14 +60,16 @@ Suite Initialization
     ...    type=string
     ...    description=AWS Account ID
     ...    pattern=\w*
+    ${AWS_ACCOUNT_NAME}=    RW.Core.Import User Variable   AWS_ACCOUNT_NAME
+    ...    type=string
+    ...    description=AWS Account Name
+    ...    pattern=\w*
     ${aws_credentials}=    RW.Core.Import Secret    aws_credentials
     ...    type=string
     ...    description=AWS credentials from the workspace (from aws-auth block; e.g. aws:access_key@cli, aws:irsa@cli).
     ...    pattern=\w*
-    ${aws_account_name_query}=       RW.CLI.Run Cli    
-    ...    cmd=aws organizations describe-account --account-id $(aws sts get-caller-identity --query 'Account' --output text) --query "Account.Name" --output text | tr -d '\n'
     ${clean_workding_dir}=    RW.CLI.Run Cli    cmd=rm -rf ${OUTPUT_DIR}/aws-c7n-s3-health         # Note: Clean out the cloud custoding report dir to ensure accurate data
-    Set Suite Variable    ${AWS_ACCOUNT_NAME}    ${aws_account_name_query.stdout}
+    Set Suite Variable    ${AWS_ACCOUNT_NAME}    ${AWS_ACCOUNT_NAME}
     Set Suite Variable    ${AWS_REGION}    ${AWS_REGION}
     Set Suite Variable    ${AWS_ACCOUNT_ID}    ${AWS_ACCOUNT_ID}
     Set Suite Variable    ${aws_credentials}    ${aws_credentials}

--- a/codebundles/aws-c7n-s3-health/sli.robot
+++ b/codebundles/aws-c7n-s3-health/sli.robot
@@ -34,15 +34,16 @@ Suite Initialization
     ...    type=string
     ...    description=AWS Account ID
     ...    pattern=\w*
+    ${AWS_ACCOUNT_NAME}=    RW.Core.Import User Variable   AWS_ACCOUNT_NAME
+    ...    type=string
+    ...    description=AWS Account Name
+    ...    pattern=\w*
     ${aws_credentials}=    RW.Core.Import Secret    aws_credentials
     ...    type=string
     ...    description=AWS credentials from the workspace (from aws-auth block; e.g. aws:access_key@cli, aws:irsa@cli).
     ...    pattern=\w*
-    # This may not work without certain permissions. We might just drop this, but unfortuinately a numberd account ID is less human friendly to include in task titles. 
-    ${aws_account_name_query}=       RW.CLI.Run Cli    
-    ...    cmd=aws organizations describe-account --account-id $(aws sts get-caller-identity --query 'Account' --output text) --query "Account.Name" --output text | tr -d '\n'
     ${clean_workding_dir}=    RW.CLI.Run Cli    cmd=rm -rf ${OUTPUT_DIR}/aws-c7n-s3-health         # Note: Clean out the cloud custoding report dir to ensure accurate data
-    Set Suite Variable    ${AWS_ACCOUNT_NAME}    ${aws_account_name_query.stdout}
+    Set Suite Variable    ${AWS_ACCOUNT_NAME}    ${AWS_ACCOUNT_NAME}
     Set Suite Variable    ${AWS_REGION}    ${AWS_REGION}
     Set Suite Variable    ${AWS_ACCOUNT_ID}    ${AWS_ACCOUNT_ID}
     Set Suite Variable    ${aws_credentials}    ${aws_credentials}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Mostly workflow/config/template string changes; behavior impact is limited to requiring `AWS_ACCOUNT_NAME` to be provided for these codebundles and could affect runs if that variable is missing.
> 
> **Overview**
> Adds a scheduled GitHub Actions workflow (`release.yaml`) that weekly generates a date-based GitHub Release.
> 
> Updates multiple AWS Cloud Custodian codebundles (ACM/EBS/EC2/Monitoring/Network/RDS/S3) to prefer `AWS_ACCOUNT_NAME` over numeric account IDs in SLX/SLI metadata and task titles, and wires `AWS_ACCOUNT_NAME` through templates/config and Robot suite initialization (removing in-run AWS Organizations account-name lookups where present).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit de10249e9b85cfe316ea88083ef9f49530f11a8d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->