### PR TITLE
Farm

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -2,7 +2,7 @@
     "name": "devtools",
     "shutdownAction": "none",
     "build": {
-        "dockerfile": "Dockerfile"
+        "dockerfile": "Dockerfile.devcontainer"
     },
     "updateRemoteUserUID": false,
     "overrideCommand": false,

--- a/.github/workflows/build-push.yaml
+++ b/.github/workflows/build-push.yaml
@@ -1,0 +1,416 @@
+name: Build And Push
+
+# Builds the codecollection image and pushes a multi-arch manifest to GHCR
+# with the tag schema the cc-registry-v2 image catalog expects:
+#
+#     <sanitized-ref>-<cc_sha7>-<rt_sha7>
+#
+# Where:
+#   sanitized-ref = github.ref_name with '/' -> '-' (e.g. "main", "feature-foo", "pr-42")
+#   cc_sha7       = first 7 chars of github.sha (this repo's commit)
+#   rt_sha7       = first 7 chars of rw-base-runtime at `runtime_ref`
+#                   (https://github.com/runwhen-contrib/rw-base-runtime)
+#
+# Architecture
+# ------------
+# The build is split across three jobs so each platform is built natively
+# rather than under QEMU emulation:
+#
+#   prepare        -- compute tag set + push flag + build args ONCE,
+#                     share with downstream jobs so they can't drift
+#   build (matrix) -- one job per platform, each on its own native runner:
+#                       linux/amd64 -> ubuntu-latest
+#                       linux/arm64 -> ubuntu-24.04-arm
+#                     each job:
+#                       1. builds the image natively (no QEMU)
+#                       2. loads it into the local docker daemon
+#                       3. runs the smoke test against the native arch
+#                       4. on push, builds again push-by-digest (no tags)
+#                          and exports the per-platform digest as an artifact
+#   merge          -- pulls the per-platform digests and uses
+#                     `docker buildx imagetools create` to stitch them
+#                     into a single multi-arch manifest under every tag
+#                     prepare computed. Pure registry-side metadata op.
+#
+# Build triggers:
+#   - push to ANY branch  -> produces a CodeCollectionVersion image for that branch
+#   - pull_request to ANY base branch -> produces a "pr-<n>" preview image
+#   - workflow_dispatch  -> manual build (e.g. to validate against a BYO base)
+#
+# We build off non-main branches on purpose: each branch is a candidate CCV
+# the catalog can pin to. Path filters skip rebuilds for pure docs / config
+# diffs.
+#
+# Dockerfile note: this workflow builds the production `Dockerfile`, which
+# uses rw-base-runtime as its base. The repo's `Dockerfile.devcontainer`
+# (referenced by .devcontainer.json) is the local-dev image and is NOT
+# built here.
+
+on:
+  push:
+    branches:
+      - '**'            # all branches; tag pushes (refs/tags/*) are excluded
+    paths-ignore:
+      - '**/*.md'
+      - '**/*.html'
+      - 'LICENSE'
+      - '.gitignore'
+      - '.gitbook.yaml'
+      - '.devcontainer.json'
+      - 'Dockerfile.devcontainer'
+      - 'CHANGELOG.md'
+      - 'CONTRIBUTING.md'
+      - 'README.md'
+      - 'SUMMARY.md'
+      - 'Introduction.md'
+      - 'docs/**'
+  pull_request:
+    # No branches: restriction -> triggers on PRs targeting any base branch
+    paths-ignore:
+      - '**/*.md'
+      - '**/*.html'
+      - 'LICENSE'
+      - '.gitignore'
+      - '.gitbook.yaml'
+      - '.devcontainer.json'
+      - 'Dockerfile.devcontainer'
+      - 'CHANGELOG.md'
+      - 'CONTRIBUTING.md'
+      - 'README.md'
+      - 'SUMMARY.md'
+      - 'Introduction.md'
+      - 'docs/**'
+  workflow_dispatch:
+    inputs:
+      base_image:
+        description: "Base image (FROM ref) to build against. Leave blank to use the Dockerfile default."
+        required: false
+        default: ""
+        type: string
+      runtime_ref:
+        description: "rw-base-runtime ref to embed in the tag suffix (branch / tag / sha). Default: main."
+        required: false
+        default: "main"
+        type: string
+      push:
+        description: "Push the resulting image to GHCR."
+        required: false
+        default: true
+        type: boolean
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE: ${{ github.repository }}
+  # The repo we resolve the rt_sha tag suffix from. MUST match the base
+  # image we FROM in Dockerfile (currently rw-base-runtime).
+  RUNTIME_REPO: runwhen-contrib/rw-base-runtime
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  # ===========================================================================
+  # prepare — single source of truth for the tag set, push flag and build
+  # args so the matrix builds and the final merge job don't drift.
+  # ===========================================================================
+  prepare:
+    runs-on: ubuntu-latest
+    outputs:
+      should_push: ${{ steps.push_flag.outputs.should_push }}
+      tags: ${{ steps.meta.outputs.tags }}
+      canonical_tag: ${{ steps.meta.outputs.canonical_tag }}
+      repo_lc: ${{ steps.meta.outputs.repo_lc }}
+      sanitized_ref: ${{ steps.meta.outputs.sanitized_ref }}
+      cc_sha: ${{ steps.meta.outputs.cc_sha }}
+      rt_sha: ${{ steps.meta.outputs.rt_sha }}
+      runtime_ref: ${{ steps.meta.outputs.runtime_ref }}
+      base_image_arg: ${{ steps.args.outputs.base_image_arg }}
+    steps:
+      - name: Determine push flag
+        id: push_flag
+        run: |
+          case "${{ github.event_name }}" in
+            push|pull_request)
+              echo "should_push=true" >> "$GITHUB_OUTPUT" ;;
+            workflow_dispatch)
+              echo "should_push=${{ inputs.push }}" >> "$GITHUB_OUTPUT" ;;
+            *)
+              echo "should_push=false" >> "$GITHUB_OUTPUT" ;;
+          esac
+
+      - name: Compute tag set
+        id: meta
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUNTIME_REF_INPUT: ${{ inputs.runtime_ref }}
+        run: |
+          set -euo pipefail
+
+          # --- this repo's sha ---
+          cc_sha="${{ github.sha }}"
+          cc_sha7="${cc_sha:0:7}"
+
+          # --- ref name (PRs collapse to "pr-<n>" since github.ref_name on
+          #     pull_request is "<n>/merge", which is useless as an OCI tag) ---
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            ref_name="pr-${{ github.event.pull_request.number }}"
+          else
+            ref_name="${{ github.ref_name }}"
+          fi
+          # OCI tags must match [A-Za-z0-9_.-]{1,128}. Replace '/' with '-'
+          # so refs like "release/1.2" survive.
+          sanitized_ref="$(echo "${ref_name}" | tr '/' '-' | tr -c 'A-Za-z0-9_.-' '-' | sed 's/^-*//;s/-*$//')"
+
+          # --- runtime sha (defaults to rw-base-runtime@main) ---
+          runtime_ref="${RUNTIME_REF_INPUT:-main}"
+          rt_sha="$(gh api "repos/${RUNTIME_REPO}/commits/${runtime_ref}" --jq '.sha')"
+          rt_sha7="${rt_sha:0:7}"
+
+          # --- repo path (GHCR rejects uppercase) ---
+          repo_lc="$(echo "${{ env.REGISTRY }}/${{ env.IMAGE }}" | tr '[:upper:]' '[:lower:]')"
+
+          # --- canonical immutable tag the catalog uses for discovery ---
+          canonical_tag="${sanitized_ref}-${cc_sha7}-${rt_sha7}"
+
+          # --- moving-pointer aliases (re-pointed on every build) ---
+          tags=( "${repo_lc}:${canonical_tag}" )
+          case "${{ github.event_name }}" in
+            push)
+              tags+=( "${repo_lc}:${sanitized_ref}" )
+              if [ "${{ github.ref_name }}" = "main" ]; then
+                tags+=( "${repo_lc}:latest" )
+              fi
+              ;;
+            pull_request)
+              tags+=( "${repo_lc}:pr-${{ github.event.pull_request.number }}" )
+              ;;
+            workflow_dispatch)
+              tags+=( "${repo_lc}:${sanitized_ref}" )
+              ;;
+          esac
+
+          {
+            echo "cc_sha=${cc_sha}"
+            echo "rt_sha=${rt_sha}"
+            echo "runtime_ref=${runtime_ref}"
+            echo "sanitized_ref=${sanitized_ref}"
+            echo "repo_lc=${repo_lc}"
+            echo "canonical_tag=${canonical_tag}"
+            printf 'tags=%s\n' "$(IFS=,; echo "${tags[*]}")"
+          } >> "$GITHUB_OUTPUT"
+
+          {
+            echo "## Will publish"
+            echo
+            for t in "${tags[@]}"; do echo "- \`${t}\`"; done
+            echo
+            echo "- Codecollection sha: \`${cc_sha}\`"
+            echo "- Runtime ref:        \`${runtime_ref}\`"
+            echo "- Runtime sha:        \`${rt_sha}\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Resolve build args
+        id: args
+        env:
+          INPUT_BASE_IMAGE: ${{ inputs.base_image }}
+        run: |
+          set -euo pipefail
+          if [ -n "${INPUT_BASE_IMAGE:-}" ]; then
+            echo "base_image_arg=BASE_IMAGE=${INPUT_BASE_IMAGE}" >> "$GITHUB_OUTPUT"
+          else
+            echo "base_image_arg=" >> "$GITHUB_OUTPUT"
+          fi
+
+  # ===========================================================================
+  # build — parallel native builds. Each matrix leg runs on a runner whose
+  # architecture matches the platform it is building, so there's no QEMU
+  # emulation cost. Smoke test runs on real hardware for each arch.
+  # ===========================================================================
+  build:
+    needs: prepare
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            arch: amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            arch: arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        if: needs.prepare.outputs.should_push == 'true'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # ----------------------------------------------------------------
+      # Phase 1: build natively + load locally so we can exec the smoke
+      # test. Per-arch GHA cache scope -- the two matrix legs run in
+      # parallel on different runners, so they MUST NOT share a scope.
+      # Cache scope is derived from the repo name so this same workflow
+      # template can be dropped into other codecollections without edits.
+      # ----------------------------------------------------------------
+      - name: Build (native, load)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile
+          platforms: ${{ matrix.platform }}
+          load: true
+          tags: ccv:smoke
+          cache-from: type=gha,scope=${{ github.event.repository.name }}-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=${{ github.event.repository.name }}-${{ matrix.arch }}
+          build-args: |
+            ${{ needs.prepare.outputs.base_image_arg }}
+
+      - name: Smoke test image
+        run: |
+          set -euo pipefail
+          # Native-arch exec -- verifies the runtime layer (rw-core-keywords
+          # imports from rw-base-runtime), the codecollection layout landed,
+          # and the worker binary is intact.
+          docker run --rm --entrypoint /bin/bash ccv:smoke -c '
+            set -eux
+            python3 -c "import RW.Core, RW.platform, RW.fetchsecrets, robot"
+            robot --version || true
+            test -d /home/runwhen/codecollection/codebundles
+            test -f /home/runwhen/codecollection/requirements.txt
+            test -x /home/runwhen/worker
+            python3 --version
+          '
+
+      # ----------------------------------------------------------------
+      # Phase 2: only on push -- rebuild push-by-digest. Writes the
+      # platform-specific manifest into the registry WITHOUT human tags.
+      # The merge job assembles the multi-arch manifest from these
+      # digests under the canonical + alias tags.
+      # ----------------------------------------------------------------
+      - name: Build & push by digest
+        id: digest_push
+        if: needs.prepare.outputs.should_push == 'true'
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile
+          platforms: ${{ matrix.platform }}
+          outputs: type=image,name=${{ needs.prepare.outputs.repo_lc }},push-by-digest=true,name-canonical=true,push=true
+          labels: |
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            io.runwhen.codecollection.commit=${{ github.sha }}
+            io.runwhen.runtime.commit=${{ needs.prepare.outputs.rt_sha }}
+            io.runwhen.runtime.ref=${{ needs.prepare.outputs.runtime_ref }}
+          cache-from: type=gha,scope=${{ github.event.repository.name }}-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=${{ github.event.repository.name }}-${{ matrix.arch }}
+          build-args: |
+            ${{ needs.prepare.outputs.base_image_arg }}
+
+      - name: Stage digest for merge job
+        if: needs.prepare.outputs.should_push == 'true'
+        run: |
+          set -euo pipefail
+          mkdir -p /tmp/digests
+          digest="${{ steps.digest_push.outputs.digest }}"
+          # Merge job enumerates files in this dir; filename = digest sans "sha256:"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        if: needs.prepare.outputs.should_push == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ matrix.arch }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  # ===========================================================================
+  # merge — combine the per-arch digests into the final multi-arch manifest
+  # under every tag prepare computed. `buildx imagetools create` is a
+  # registry-side metadata op -- no image rebuild.
+  # ===========================================================================
+  merge:
+    needs: [prepare, build]
+    if: needs.prepare.outputs.should_push == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digests-*
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create multi-arch manifest
+        env:
+          REPO_LC: ${{ needs.prepare.outputs.repo_lc }}
+          TAG_CSV: ${{ needs.prepare.outputs.tags }}
+        run: |
+          set -euo pipefail
+          tag_args=()
+          IFS=',' read -ra TAGS <<< "${TAG_CSV}"
+          for t in "${TAGS[@]}"; do tag_args+=(-t "$t"); done
+
+          digest_args=()
+          for f in /tmp/digests/*; do
+            d="$(basename "$f")"
+            digest_args+=("${REPO_LC}@sha256:${d}")
+          done
+
+          echo "Tags:    ${TAGS[*]}"
+          echo "Digests: ${digest_args[*]}"
+
+          docker buildx imagetools create "${tag_args[@]}" "${digest_args[@]}"
+
+      - name: Inspect resulting manifest
+        env:
+          TAG_CSV: ${{ needs.prepare.outputs.tags }}
+        run: |
+          set -euo pipefail
+          IFS=',' read -ra TAGS <<< "${TAG_CSV}"
+          docker buildx imagetools inspect "${TAGS[0]}"
+
+      - name: Summary
+        env:
+          REPO_LC: ${{ needs.prepare.outputs.repo_lc }}
+          CANONICAL_TAG: ${{ needs.prepare.outputs.canonical_tag }}
+          TAG_CSV: ${{ needs.prepare.outputs.tags }}
+        run: |
+          {
+            echo "## ${{ github.event.repository.name }} build"
+            echo
+            echo "- Event:               \`${{ github.event_name }}\`"
+            echo "- Ref:                 \`${{ github.ref }}\`"
+            echo "- Codecollection sha:  \`${{ github.sha }}\`"
+            echo "- Runtime ref:         \`${{ needs.prepare.outputs.runtime_ref }}\`"
+            echo "- Runtime sha:         \`${{ needs.prepare.outputs.rt_sha }}\`"
+            echo "- Canonical tag:       \`${REPO_LC}:${CANONICAL_TAG}\`"
+            echo "- Pushed:              \`true\`"
+            echo
+            echo "### Published manifest"
+            IFS=',' read -ra TAGS <<< "${TAG_CSV}"
+            for t in "${TAGS[@]}"; do echo "- \`${t}\`"; done
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,24 @@
+name: Release (Date-based)
+
+on:
+  schedule:
+    - cron: '0 12 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: true
+
+      - name: Create Release
+        uses: runwhen-contrib/github-actions/generate-release@main
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,34 +1,47 @@
-FROM us-docker.pkg.dev/runwhen-nonprod-shared/public-images/codecollection-devtools:latest
+# Production codecollection image — the CCV image the RunWhen platform pulls.
+#
+# Source FROM the unified rw-base-runtime, which ships:
+#   - Python 3 + the worker binary at /home/runwhen/worker
+#   - rw-core-keywords pip-installed system-wide (RW.Core / RW.platform /
+#     RW.fetchsecrets) and the rw-base-runtime helper scripts at
+#     /home/runwhen/robot-runtime/
+#   - Standard CLI tooling (kubectl, aws, az, gcloud, helm, gh, jq, yq, ...)
+#
+# Source: https://github.com/runwhen-contrib/rw-base-runtime
+#
+# For interactive local development see Dockerfile.devcontainer (referenced
+# by .devcontainer.json). It still uses codecollection-devtools and ships
+# extra dev tooling. The two image families are intentionally separate
+# during the transition; long-term we'll converge.
+#
+# Override at build time to pin a specific runtime sha or test a BYO base:
+#
+#   docker build \
+#     --build-arg BASE_IMAGE=ghcr.io/runwhen-contrib/rw-base-runtime:<sha7> \
+#     ...
+#
+# The CI workflow (.github/workflows/build-push.yaml) resolves the
+# `runtime_ref` dispatch input to an rw-base-runtime commit sha and bakes
+# that sha into the resulting image tag suffix.
+ARG BASE_IMAGE=ghcr.io/runwhen-contrib/rw-base-runtime:latest
+FROM ${BASE_IMAGE}
 USER root
 
 ENV RUNWHEN_HOME=/home/runwhen
 ENV PATH "$PATH:/usr/local/bin:/home/runwhen/.local/bin"
 
-# Set up directories and permissions
 RUN mkdir -p $RUNWHEN_HOME/codecollection
 WORKDIR $RUNWHEN_HOME/codecollection
 
-# Copy files into container with correct ownership
 COPY --chown=runwhen:0 . .
 
-# Check and install requirements if requirements.txt exists
 RUN if [ -f "requirements.txt" ]; then pip install --no-cache-dir -r requirements.txt; else echo "requirements.txt not found, skipping pip install"; fi
 
-# Install additional user packages
-#RUN apt-get update && \
-#    apt-get install -y --no-install-recommends net-tools && \
-#    apt-get clean && \
-#    rm -rf /var/lib/apt/lists/* /var/cache/apt
-
-# Add runwhen user to sudoers with no password prompt
 RUN echo "runwhen ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
 
-# Set RunWhen Temp Dir
 RUN mkdir -p /var/tmp/runwhen && chmod 1777 /var/tmp/runwhen
 ENV TMPDIR=/var/tmp/runwhen
 
-# Adjust permissions for runwhen user
 RUN chown runwhen:0 -R $RUNWHEN_HOME/codecollection
 
-# Switch to runwhen user
 USER runwhen

--- a/Dockerfile.devcontainer
+++ b/Dockerfile.devcontainer
@@ -1,0 +1,34 @@
+FROM us-docker.pkg.dev/runwhen-nonprod-shared/public-images/codecollection-devtools:latest
+USER root
+
+ENV RUNWHEN_HOME=/home/runwhen
+ENV PATH "$PATH:/usr/local/bin:/home/runwhen/.local/bin"
+
+# Set up directories and permissions
+RUN mkdir -p $RUNWHEN_HOME/codecollection
+WORKDIR $RUNWHEN_HOME/codecollection
+
+# Copy files into container with correct ownership
+COPY --chown=runwhen:0 . .
+
+# Check and install requirements if requirements.txt exists
+RUN if [ -f "requirements.txt" ]; then pip install --no-cache-dir -r requirements.txt; else echo "requirements.txt not found, skipping pip install"; fi
+
+# Install additional user packages
+#RUN apt-get update && \
+#    apt-get install -y --no-install-recommends net-tools && \
+#    apt-get clean && \
+#    rm -rf /var/lib/apt/lists/* /var/cache/apt
+
+# Add runwhen user to sudoers with no password prompt
+RUN echo "runwhen ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
+
+# Set RunWhen Temp Dir
+RUN mkdir -p /var/tmp/runwhen && chmod 1777 /var/tmp/runwhen
+ENV TMPDIR=/var/tmp/runwhen
+
+# Adjust permissions for runwhen user
+RUN chown runwhen:0 -R $RUNWHEN_HOME/codecollection
+
+# Switch to runwhen user
+USER runwhen

--- a/codebundles/aws-c7n-acm-health/.runwhen/templates/aws-c7n-acm-health-sli.yaml
+++ b/codebundles/aws-c7n-acm-health/.runwhen/templates/aws-c7n-acm-health-sli.yaml
@@ -11,7 +11,7 @@ spec:
   displayUnitsShort: ok
   locations:
       - {{default_location}}
-  description: Count AWS ACM certificates that are unused, expiring, expired, or failed in AWS region {{match_resource.resource.region}} and account {{match_resource.resource.account_id}}
+  description: Count AWS ACM certificates that are unused, expiring, expired, or failed in AWS region {{match_resource.resource.region}} and account {{match_resource.account_name}}
   codeBundle:
     {% if repo_url %}
     repoUrl: {{repo_url}}

--- a/codebundles/aws-c7n-acm-health/.runwhen/templates/aws-c7n-acm-health-sli.yaml
+++ b/codebundles/aws-c7n-acm-health/.runwhen/templates/aws-c7n-acm-health-sli.yaml
@@ -31,6 +31,8 @@ spec:
       value: "{{match_resource.resource.region}}"
     - name: AWS_ACCOUNT_ID
       value: "{{match_resource.resource.account_id}}"
+    - name: AWS_ACCOUNT_NAME
+      value: "{{match_resource.account_name}}"
   secretsProvided:
     {% include "aws-auth.yaml" ignore missing %}
   alerts:

--- a/codebundles/aws-c7n-acm-health/.runwhen/templates/aws-c7n-acm-health-slx.yaml
+++ b/codebundles/aws-c7n-acm-health/.runwhen/templates/aws-c7n-acm-health-slx.yaml
@@ -8,8 +8,8 @@ metadata:
     {% include "common-annotations.yaml" %}
 spec:
   imageURL: https://storage.googleapis.com/runwhen-nonprod-shared-images/icons/aws/certificate_manager.svg
-  alias: AWS ACM Health For Region {{match_resource.resource.region}} in Account {{match_resource.resource.account_id}}
-  asMeasuredBy: The number of AWS ACM certificates that are unused, expiring or expired and failed status in region {{match_resource.resource.region}} and account {{match_resource.resource.account_id}}
+  alias: AWS ACM Health For Region {{match_resource.resource.region}} in Account {{match_resource.account_name}}
+  asMeasuredBy: The number of AWS ACM certificates that are unused, expiring or expired and failed status in region {{match_resource.resource.region}} and account {{match_resource.account_name}}
   configProvided:
   - name: SLX_PLACEHOLDER
     value: SLX_PLACEHOLDER

--- a/codebundles/aws-c7n-acm-health/.runwhen/templates/aws-c7n-acm-health-taskset.yaml
+++ b/codebundles/aws-c7n-acm-health/.runwhen/templates/aws-c7n-acm-health-taskset.yaml
@@ -26,5 +26,7 @@ spec:
       value: "{{match_resource.resource.region}}"
     - name: AWS_ACCOUNT_ID
       value: "{{match_resource.resource.account_id}}"
+    - name: AWS_ACCOUNT_NAME
+      value: "{{match_resource.account_name}}"
   secretsProvided:
     {% include "aws-auth.yaml" ignore missing %}

--- a/codebundles/aws-c7n-acm-health/runbook.robot
+++ b/codebundles/aws-c7n-acm-health/runbook.robot
@@ -12,7 +12,7 @@ Library    CloudCustodian.Core
 Suite Setup    Suite Initialization
 
 *** Tasks ***
-List Unused ACM Certificates in AWS Region `${AWS_REGION}` in AWS Account `${AWS_ACCOUNT_ID}`
+List Unused ACM Certificates in AWS Region `${AWS_REGION}` in AWS Account `${AWS_ACCOUNT_NAME}`
     [Documentation]  Find unused ACM certificates
     [Tags]    aws    acm    certificate    security    data:config
     ${c7n_output}=    RW.CLI.Run Cli
@@ -54,7 +54,7 @@ List Unused ACM Certificates in AWS Region `${AWS_REGION}` in AWS Account `${AWS
         RW.Core.Add Pre To Report    No unused ACM certificates found in AWS Region `${AWS_REGION}` in AWS Account `${AWS_ACCOUNT_ID}`
     END
 
-List Expiring ACM Certificates in AWS Region `${AWS_REGION}` in AWS Account `${AWS_ACCOUNT_ID}`
+List Expiring ACM Certificates in AWS Region `${AWS_REGION}` in AWS Account `${AWS_ACCOUNT_NAME}`
     [Documentation]  Find Expiring ACM certificates
     [Tags]    aws    acm    certificate    expiration    data:config
     CloudCustodian.Core.Generate Policy   
@@ -100,7 +100,7 @@ List Expiring ACM Certificates in AWS Region `${AWS_REGION}` in AWS Account `${A
         RW.Core.Add Pre To Report    No ACM certificates nearing expiration found in AWS Region `${AWS_REGION}` in AWS Account `${AWS_ACCOUNT_ID}`
     END
 
-List Expired ACM Certificates in AWS Region `${AWS_REGION}` in AWS Account `${AWS_ACCOUNT_ID}`
+List Expired ACM Certificates in AWS Region `${AWS_REGION}` in AWS Account `${AWS_ACCOUNT_NAME}`
     [Documentation]  Find expired ACM certificates
     [Tags]    aws    acm    certificate    expiration    data:config
     ${c7n_output}=    RW.CLI.Run Cli
@@ -141,7 +141,7 @@ List Expired ACM Certificates in AWS Region `${AWS_REGION}` in AWS Account `${AW
         RW.Core.Add Pre To Report    No expired ACM certificates found in AWS Region `${AWS_REGION}` in AWS Account `${AWS_ACCOUNT_ID}`
     END
 
-List Failed Status ACM Certificates in AWS Region `${AWS_REGION}` in AWS Account `${AWS_ACCOUNT_ID}`
+List Failed Status ACM Certificates in AWS Region `${AWS_REGION}` in AWS Account `${AWS_ACCOUNT_NAME}`
     [Documentation]  Find failed status ACM certificates
     [Tags]    aws    acm    certificate    status    data:config
     ${c7n_output}=    RW.CLI.Run Cli
@@ -183,7 +183,7 @@ List Failed Status ACM Certificates in AWS Region `${AWS_REGION}` in AWS Account
         RW.Core.Add Pre To Report    No ACM certificates in failed status found in AWS Region `${AWS_REGION}` in AWS Account `${AWS_ACCOUNT_ID}`
     END
 
-List Pending Validation ACM Certificates in AWS Region `${AWS_REGION}` in AWS Account `${AWS_ACCOUNT_ID}`
+List Pending Validation ACM Certificates in AWS Region `${AWS_REGION}` in AWS Account `${AWS_ACCOUNT_NAME}`
     [Documentation]  Find pending validation ACM certificates
     [Tags]    aws    acm    certificate    status    data:config
     ${c7n_output}=    RW.CLI.Run Cli
@@ -236,6 +236,10 @@ Suite Initialization
     ...    type=string
     ...    description=AWS Account ID
     ...    pattern=\w*
+    ${AWS_ACCOUNT_NAME}=    RW.Core.Import User Variable   AWS_ACCOUNT_NAME
+    ...    type=string
+    ...    description=AWS Account Name
+    ...    pattern=\w*
     ${aws_credentials}=    RW.Core.Import Secret    aws_credentials
     ...    type=string
     ...    description=AWS credentials from the workspace (from aws-auth block; e.g. aws:access_key@cli, aws:irsa@cli).
@@ -250,6 +254,7 @@ Suite Initialization
     Set Suite Variable    ${AWS_REGION}    ${AWS_REGION}
     Set Suite Variable    ${CERT_EXPIRY_DAYS}    ${CERT_EXPIRY_DAYS}
     Set Suite Variable    ${AWS_ACCOUNT_ID}    ${AWS_ACCOUNT_ID}
+    Set Suite Variable    ${AWS_ACCOUNT_NAME}    ${AWS_ACCOUNT_NAME}
     Set Suite Variable    ${aws_credentials}    ${aws_credentials}
     # AWS credentials are provided by the platform from the aws-auth block (runwhen-local);
     # the runtime uses aws_utils to set up the auth environment (IRSA, access key, assume role, etc.).

--- a/codebundles/aws-c7n-acm-health/sli.robot
+++ b/codebundles/aws-c7n-acm-health/sli.robot
@@ -12,7 +12,7 @@ Library    CloudCustodian.Core
 Suite Setup    Suite Initialization
 
 *** Tasks ***
-Check for unused ACM certificates in AWS Region `${AWS_REGION}` in AWS account `${AWS_ACCOUNT_ID}`
+Check for unused ACM certificates in AWS Region `${AWS_REGION}` in AWS account `${AWS_ACCOUNT_NAME}`
     [Documentation]  Find unused ACM certificates
     [Tags]    aws    acm    certificate    security    data:config
     ${c7n_output}=    RW.CLI.Run Cli
@@ -23,7 +23,7 @@ Check for unused ACM certificates in AWS Region `${AWS_REGION}` in AWS account `
     ${unused_certificate_score}=    Evaluate    1 if int(${count.stdout}) <= int(${MAX_UNUSED_CERTIFICATES}) else 0
     Set Global Variable    ${unused_certificate_score}
 
-Check for Expiring ACM certificates in AWS Region `${AWS_REGION}` in AWS account `${AWS_ACCOUNT_ID}`
+Check for Expiring ACM certificates in AWS Region `${AWS_REGION}` in AWS account `${AWS_ACCOUNT_NAME}`
     [Documentation]  Find Expiring ACM certificates
     [Tags]    aws    acm    certificate    expiration    data:config
     CloudCustodian.Core.Generate Policy   
@@ -37,7 +37,7 @@ Check for Expiring ACM certificates in AWS Region `${AWS_REGION}` in AWS account
     ${expiring_certificate_score}=    Evaluate    1 if int(${count.stdout}) <= int(${MAX_EXPIRING_CERTIFICATES}) else 0
     Set Global Variable    ${expiring_certificate_score}
 
-Check for expired ACM certificates in AWS Region `${AWS_REGION}` in AWS account `${AWS_ACCOUNT_ID}`
+Check for expired ACM certificates in AWS Region `${AWS_REGION}` in AWS account `${AWS_ACCOUNT_NAME}`
     [Documentation]  Find expired ACM certificates
     [Tags]    aws    acm    certificate    expiration    data:config
     ${c7n_output}=    RW.CLI.Run Cli
@@ -48,7 +48,7 @@ Check for expired ACM certificates in AWS Region `${AWS_REGION}` in AWS account 
     ${expired_certificate_score}=    Evaluate    1 if int(${count.stdout}) <= int(${MAX_EXPIRED_CERTIFICATES}) else 0
     Set Global Variable    ${expired_certificate_score}
 
-Check for Failed Status ACM Certificates in AWS Region `${AWS_REGION}` in AWS Account `${AWS_ACCOUNT_ID}`
+Check for Failed Status ACM Certificates in AWS Region `${AWS_REGION}` in AWS Account `${AWS_ACCOUNT_NAME}`
     [Documentation]  Find failed status ACM certificates
     [Tags]    aws    acm    certificate    status    data:config
     ${c7n_output}=    RW.CLI.Run Cli
@@ -59,7 +59,7 @@ Check for Failed Status ACM Certificates in AWS Region `${AWS_REGION}` in AWS Ac
     ${failed_certificate_score}=    Evaluate    1 if int(${count.stdout}) <= int(${MAX_FAILED_CERTIFICATES}) else 0
     Set Global Variable    ${failed_certificate_score}
 
-Check for Pending Validation ACM Certificates in AWS Region `${AWS_REGION}` in AWS Account `${AWS_ACCOUNT_ID}`
+Check for Pending Validation ACM Certificates in AWS Region `${AWS_REGION}` in AWS Account `${AWS_ACCOUNT_NAME}`
     [Documentation]  Find pending validation ACM certificates
     [Tags]    aws    acm    certificate    validation    data:config
     ${c7n_output}=    RW.CLI.Run Cli
@@ -84,6 +84,10 @@ Suite Initialization
     ${AWS_ACCOUNT_ID}=    RW.Core.Import User Variable   AWS_ACCOUNT_ID
     ...    type=string
     ...    description=AWS Account ID
+    ...    pattern=\w*
+    ${AWS_ACCOUNT_NAME}=    RW.Core.Import User Variable   AWS_ACCOUNT_NAME
+    ...    type=string
+    ...    description=AWS Account Name
     ...    pattern=\w*
     ${aws_credentials}=    RW.Core.Import Secret    aws_credentials
     ...    type=string
@@ -128,6 +132,7 @@ Suite Initialization
     ${clean_workding_dir}=    RW.CLI.Run Cli    cmd=rm -rf ${OUTPUT_DIR}/aws-c7n-acm-health
     Set Suite Variable    ${AWS_REGION}    ${AWS_REGION}
     Set Suite Variable    ${AWS_ACCOUNT_ID}    ${AWS_ACCOUNT_ID}
+    Set Suite Variable    ${AWS_ACCOUNT_NAME}    ${AWS_ACCOUNT_NAME}
     Set Suite Variable    ${CERT_EXPIRY_DAYS}    ${CERT_EXPIRY_DAYS}
     Set Suite Variable    ${MAX_UNUSED_CERTIFICATES}    ${MAX_UNUSED_CERTIFICATES}
     Set Suite Variable    ${MAX_FAILED_CERTIFICATES}    ${MAX_FAILED_CERTIFICATES}

--- a/codebundles/aws-c7n-ebs-health/.runwhen/templates/aws-c7n-ebs-health-sli.yaml
+++ b/codebundles/aws-c7n-ebs-health/.runwhen/templates/aws-c7n-ebs-health-sli.yaml
@@ -31,6 +31,8 @@ spec:
       value: "{{match_resource.resource.region}}"
     - name: AWS_ACCOUNT_ID
       value: "{{match_resource.resource.account_id}}"
+    - name: AWS_ACCOUNT_NAME
+      value: "{{match_resource.account_name}}"
   secretsProvided:
     {% include "aws-auth.yaml" ignore missing %}
   alerts:

--- a/codebundles/aws-c7n-ebs-health/.runwhen/templates/aws-c7n-ebs-health-sli.yaml
+++ b/codebundles/aws-c7n-ebs-health/.runwhen/templates/aws-c7n-ebs-health-sli.yaml
@@ -11,7 +11,7 @@ spec:
   displayUnitsShort: ok
   locations:
       - {{default_location}}
-  description: Measures security and health of AWS EBS volumes in AWS region {{match_resource.resource.region}} and account {{match_resource.resource.account_id}}
+  description: Measures security and health of AWS EBS volumes in AWS region {{match_resource.resource.region}} and account {{match_resource.account_name}}
   codeBundle:
     {% if repo_url %}
     repoUrl: {{repo_url}}

--- a/codebundles/aws-c7n-ebs-health/.runwhen/templates/aws-c7n-ebs-health-slx.yaml
+++ b/codebundles/aws-c7n-ebs-health/.runwhen/templates/aws-c7n-ebs-health-slx.yaml
@@ -8,8 +8,8 @@ metadata:
     {% include "common-annotations.yaml" %}
 spec:
   imageURL: https://storage.googleapis.com/runwhen-nonprod-shared-images/icons/aws/Resource-Icons_06072024/Res_Storage/Res_Amazon-Elastic-Block-Store_Multiple-Volumes_48.png
-  alias: AWS EBS Health For Region {{match_resource.resource.region}} in Account {{match_resource.resource.account_id}}
-  asMeasuredBy: The number of AWS EBS volumes and snapshots in region {{match_resource.resource.region}} and account {{match_resource.resource.account_id}}
+  alias: AWS EBS Health For Region {{match_resource.resource.region}} in Account {{match_resource.account_name}}
+  asMeasuredBy: The number of AWS EBS volumes and snapshots in region {{match_resource.resource.region}} and account {{match_resource.account_name}}
   configProvided:
   - name: SLX_PLACEHOLDER
     value: SLX_PLACEHOLDER

--- a/codebundles/aws-c7n-ebs-health/.runwhen/templates/aws-c7n-ebs-health-taskset.yaml
+++ b/codebundles/aws-c7n-ebs-health/.runwhen/templates/aws-c7n-ebs-health-taskset.yaml
@@ -26,5 +26,7 @@ spec:
       value: "{{match_resource.resource.region}}"
     - name: AWS_ACCOUNT_ID
       value: "{{match_resource.resource.account_id}}"
+    - name: AWS_ACCOUNT_NAME
+      value: "{{match_resource.account_name}}"
   secretsProvided:
     {% include "aws-auth.yaml" ignore missing %}

--- a/codebundles/aws-c7n-ebs-health/runbook.robot
+++ b/codebundles/aws-c7n-ebs-health/runbook.robot
@@ -14,7 +14,7 @@ Suite Setup    Suite Initialization
 
 
 *** Tasks ***
-List Unattached EBS Volumes in AWS Region `${AWS_REGION}` in AWS account `${AWS_ACCOUNT_ID}` 
+List Unattached EBS Volumes in AWS Region `${AWS_REGION}` in AWS account `${AWS_ACCOUNT_NAME}` 
     [Documentation]  Check for unattached EBS volumes in the specified region. 
     [Tags]    ebs    storage    aws    volume    unattached    data:config
     ${c7n_output}=    RW.CLI.Run Cli
@@ -51,7 +51,7 @@ List Unattached EBS Volumes in AWS Region `${AWS_REGION}` in AWS account `${AWS_
     END
 
 
-List Unencrypted EBS Volumes in AWS Region `${AWS_REGION}` in AWS account `${AWS_ACCOUNT_ID}`
+List Unencrypted EBS Volumes in AWS Region `${AWS_REGION}` in AWS account `${AWS_ACCOUNT_NAME}`
     [Documentation]  Check for Unencrypted EBS Volumes in the specified region. 
     [Tags]    ebs    storage    aws    volume    encryption    data:config
     ${c7n_output}=    RW.CLI.Run Cli
@@ -88,7 +88,7 @@ List Unencrypted EBS Volumes in AWS Region `${AWS_REGION}` in AWS account `${AWS
     END
 
 
-List Unused EBS Snapshots in AWS Region `${AWS_REGION}` in AWS account `${AWS_ACCOUNT_ID}`
+List Unused EBS Snapshots in AWS Region `${AWS_REGION}` in AWS account `${AWS_ACCOUNT_NAME}`
     [Documentation]  Check for Unused EBS Snapshots in the specified region. 
     [Tags]    ebs    storage    aws    volume    unused    data:config
     ${c7n_output}=    RW.CLI.Run Cli
@@ -134,6 +134,10 @@ Suite Initialization
     ...    type=string
     ...    description=AWS Account ID
     ...    pattern=\w*
+    ${AWS_ACCOUNT_NAME}=    RW.Core.Import User Variable   AWS_ACCOUNT_NAME
+    ...    type=string
+    ...    description=AWS Account Name
+    ...    pattern=\w*
     ${aws_credentials}=    RW.Core.Import Secret    aws_credentials
     ...    type=string
     ...    description=AWS credentials from the workspace (from aws-auth block; e.g. aws:access_key@cli, aws:irsa@cli).
@@ -141,6 +145,7 @@ Suite Initialization
     ${clean_workding_dir}=    RW.CLI.Run Cli    cmd=rm -rf ${OUTPUT_DIR}/aws-c7n-ebs-health         # Note: Clean out the cloud custoding report dir to ensure accurate data
     Set Suite Variable    ${AWS_REGION}    ${AWS_REGION}
     Set Suite Variable    ${AWS_ACCOUNT_ID}    ${AWS_ACCOUNT_ID}
+    Set Suite Variable    ${AWS_ACCOUNT_NAME}    ${AWS_ACCOUNT_NAME}
     Set Suite Variable    ${aws_credentials}    ${aws_credentials}
     # AWS credentials are provided by the platform from the aws-auth block (runwhen-local);
     # the runtime uses aws_utils to set up the auth environment (IRSA, access key, assume role, etc.).

--- a/codebundles/aws-c7n-ebs-health/runbook.robot
+++ b/codebundles/aws-c7n-ebs-health/runbook.robot
@@ -138,10 +138,7 @@ Suite Initialization
     ...    type=string
     ...    description=AWS credentials from the workspace (from aws-auth block; e.g. aws:access_key@cli, aws:irsa@cli).
     ...    pattern=\w*
-    ${aws_account_name_query}=       RW.CLI.Run Cli    
-    ...    cmd=aws organizations describe-account --account-id $(aws sts get-caller-identity --query 'Account' --output text) --query "Account.Name" --output text | tr -d '\n'
     ${clean_workding_dir}=    RW.CLI.Run Cli    cmd=rm -rf ${OUTPUT_DIR}/aws-c7n-ebs-health         # Note: Clean out the cloud custoding report dir to ensure accurate data
-    Set Suite Variable    ${AWS_ACCOUNT_NAME}    ${aws_account_name_query.stdout}
     Set Suite Variable    ${AWS_REGION}    ${AWS_REGION}
     Set Suite Variable    ${AWS_ACCOUNT_ID}    ${AWS_ACCOUNT_ID}
     Set Suite Variable    ${aws_credentials}    ${aws_credentials}

--- a/codebundles/aws-c7n-ebs-health/sli.robot
+++ b/codebundles/aws-c7n-ebs-health/sli.robot
@@ -61,6 +61,10 @@ Suite Initialization
     ...    type=string
     ...    description=AWS Account ID
     ...    pattern=\w*
+    ${AWS_ACCOUNT_NAME}=    RW.Core.Import User Variable   AWS_ACCOUNT_NAME
+    ...    type=string
+    ...    description=AWS Account Name
+    ...    pattern=\w*
     ${aws_credentials}=    RW.Core.Import Secret    aws_credentials
     ...    type=string
     ...    description=AWS credentials from the workspace (from aws-auth block; e.g. aws:access_key@cli, aws:irsa@cli).
@@ -80,6 +84,7 @@ Suite Initialization
     ${clean_workding_dir}=    RW.CLI.Run Cli    cmd=rm -rf ${OUTPUT_DIR}/aws-c7n-ebs-health         # Note: Clean out the cloud custoding report dir to ensure accurate data
     Set Suite Variable    ${AWS_REGION}    ${AWS_REGION}
     Set Suite Variable    ${AWS_ACCOUNT_ID}    ${AWS_ACCOUNT_ID}
+    Set Suite Variable    ${AWS_ACCOUNT_NAME}    ${AWS_ACCOUNT_NAME}
     Set Suite Variable    ${EVENT_THRESHOLD}    ${EVENT_THRESHOLD}
     Set Suite Variable    ${SECURITY_EVENT_THRESHOLD}    ${SECURITY_EVENT_THRESHOLD}
     Set Suite Variable    ${aws_credentials}    ${aws_credentials}

--- a/codebundles/aws-c7n-ec2-health/.runwhen/templates/aws-c7n-ec2-health-sli.yaml
+++ b/codebundles/aws-c7n-ec2-health/.runwhen/templates/aws-c7n-ec2-health-sli.yaml
@@ -11,7 +11,7 @@ spec:
   displayUnitsShort: ok
   locations:
       - {{default_location}}
-  description: Count the number of EC2 instances that are stale or stopped in this AWS region {{match_resource.resource.region}} and account {{match_resource.resource.account_id}}
+  description: Count the number of EC2 instances that are stale or stopped in this AWS region {{match_resource.resource.region}} and account {{match_resource.account_name}}
   codeBundle:
     {% if repo_url %}
     repoUrl: {{repo_url}}

--- a/codebundles/aws-c7n-ec2-health/.runwhen/templates/aws-c7n-ec2-health-sli.yaml
+++ b/codebundles/aws-c7n-ec2-health/.runwhen/templates/aws-c7n-ec2-health-sli.yaml
@@ -31,6 +31,8 @@ spec:
       value: "{{match_resource.resource.region}}"
     - name: AWS_ACCOUNT_ID
       value: "{{match_resource.resource.account_id}}"
+    - name: AWS_ACCOUNT_NAME
+      value: "{{match_resource.account_name}}"
     - name: AWS_EC2_AGE
       value: '60'
     - name: AWS_EC2_TAGS

--- a/codebundles/aws-c7n-ec2-health/.runwhen/templates/aws-c7n-ec2-health-slx.yaml
+++ b/codebundles/aws-c7n-ec2-health/.runwhen/templates/aws-c7n-ec2-health-slx.yaml
@@ -8,14 +8,14 @@ metadata:
     {% include "common-annotations.yaml" %}
 spec:
   imageURL: https://storage.googleapis.com/runwhen-nonprod-shared-images/icons/aws/Resource-Icons_06072024/Res_Compute/Res_Amazon-EC2_Instances_48.svg
-  alias: AWS EC2 Health For Region {{match_resource.resource.region}} in Account {{match_resource.resource.account_id}}
-  asMeasuredBy: The number of stale and stopped EC2 instances in region {{match_resource.resource.region}} and account {{match_resource.resource.account_id}}
+  alias: AWS EC2 Health For Region {{match_resource.resource.region}} in Account {{match_resource.account_name}}
+  asMeasuredBy: The number of stale and stopped EC2 instances in region {{match_resource.resource.region}} and account {{match_resource.account_name}}
   configProvided:
   - name: SLX_PLACEHOLDER
     value: SLX_PLACEHOLDER
   owners:
   - {{workspace.owner_email}}
-  statement: Identify stale and stopped EC2 instances that may pose security risks due to missed updates or inactivity in the region {{match_resource.resource.region}} and account {{match_resource.resource.account_id}}
+  statement: Identify stale and stopped EC2 instances that may pose security risks due to missed updates or inactivity in the region {{match_resource.resource.region}} and account {{match_resource.account_name}}
   additionalContext:
     {% include "aws-hierarchy.yaml" ignore missing %}
     qualified_name: "{{ match_resource.qualified_name | replace(":", "_") }}"

--- a/codebundles/aws-c7n-ec2-health/.runwhen/templates/aws-c7n-ec2-health-taskset.yaml
+++ b/codebundles/aws-c7n-ec2-health/.runwhen/templates/aws-c7n-ec2-health-taskset.yaml
@@ -26,6 +26,8 @@ spec:
       value: "{{match_resource.resource.region}}"
     - name: AWS_ACCOUNT_ID
       value: "{{match_resource.resource.account_id}}"
+    - name: AWS_ACCOUNT_NAME
+      value: "{{match_resource.account_name}}"
     - name: AWS_EC2_AGE
       value: '60'
     - name: AWS_EC2_TAGS

--- a/codebundles/aws-c7n-ec2-health/runbook.robot
+++ b/codebundles/aws-c7n-ec2-health/runbook.robot
@@ -13,7 +13,7 @@ Suite Setup    Suite Initialization
 
 
 *** Tasks ***
-List stale AWS EC2 instances in AWS Region `${AWS_REGION}` in AWS account `${AWS_ACCOUNT_ID}` 
+List stale AWS EC2 instances in AWS Region `${AWS_REGION}` in AWS account `${AWS_ACCOUNT_NAME}` 
     [Documentation]  List stale EC2 instances in AWS Region. 
     [Tags]    ec2    instance    aws    compute    stale    data:config
 
@@ -65,7 +65,7 @@ List stale AWS EC2 instances in AWS Region `${AWS_REGION}` in AWS account `${AWS
         RW.Core.Add Pre To Report     ${ec2_instances_list_length} stale instances found, below threshold of ${MAX_ALLOWED_STALE_INSTANCES}\n${report_data.stdout}
     END
 
-List stopped AWS EC2 instances in AWS Region `${AWS_REGION}` in AWS account `${AWS_ACCOUNT_ID}` 
+List stopped AWS EC2 instances in AWS Region `${AWS_REGION}` in AWS account `${AWS_ACCOUNT_NAME}` 
     [Documentation]  List stopped EC2 instances in AWS Region. 
     [Tags]    ec2    instance    aws    compute    data:config
     
@@ -118,7 +118,7 @@ List stopped AWS EC2 instances in AWS Region `${AWS_REGION}` in AWS account `${A
         RW.Core.Add Pre To Report    ${ec2_instances_list_length} stopped instances found, below threshold of ${MAX_ALLOWED_STOPPED_INSTANCES}\n${report_data.stdout}
     END
 
-List invalid AWS Auto Scaling Groups in AWS Region ${AWS_REGION} in AWS account ${AWS_ACCOUNT_ID}
+List invalid AWS Auto Scaling Groups in AWS Region ${AWS_REGION} in AWS account ${AWS_ACCOUNT_NAME}
     [Documentation]  List invalid Auto Scaling Groups
     [Tags]    asg    aws    compute    asg    data:config
 
@@ -197,6 +197,10 @@ Suite Initialization
     ...    type=string
     ...    description=AWS Account ID
     ...    pattern=\w*
+    ${AWS_ACCOUNT_NAME}=    RW.Core.Import User Variable   AWS_ACCOUNT_NAME
+    ...    type=string
+    ...    description=AWS Account Name
+    ...    pattern=\w*
     ${aws_credentials}=    RW.Core.Import Secret    aws_credentials
     ...    type=string
     ...    description=AWS credentials from the workspace (from aws-auth block; e.g. aws:access_key@cli, aws:irsa@cli).
@@ -236,6 +240,7 @@ Suite Initialization
     Set Suite Variable    ${AWS_EC2_TAGS}    ${AWS_EC2_TAGS}
     Set Suite Variable    ${AWS_REGION}    ${AWS_REGION}
     Set Suite Variable    ${AWS_ACCOUNT_ID}    ${AWS_ACCOUNT_ID}
+    Set Suite Variable    ${AWS_ACCOUNT_NAME}    ${AWS_ACCOUNT_NAME}
     Set Suite Variable    ${MAX_ALLOWED_STOPPED_INSTANCES}    ${MAX_ALLOWED_STOPPED_INSTANCES}
     Set Suite Variable    ${MAX_ALLOWED_STALE_INSTANCES}    ${MAX_ALLOWED_STALE_INSTANCES}
     Set Suite Variable    ${MAX_ALLOWED_INVALID_ASG}    ${MAX_ALLOWED_INVALID_ASG}

--- a/codebundles/aws-c7n-ec2-health/sli.robot
+++ b/codebundles/aws-c7n-ec2-health/sli.robot
@@ -13,7 +13,7 @@ Suite Setup    Suite Initialization
 
 
 *** Tasks ***
-Check for stale AWS EC2 instances in AWS Region `${AWS_REGION}` in AWS account `${AWS_ACCOUNT_ID}` 
+Check for stale AWS EC2 instances in AWS Region `${AWS_REGION}` in AWS account `${AWS_ACCOUNT_NAME}` 
     [Documentation]  Check for stale EC2 instances in AWS Region. 
     [Tags]    ec2    instance    aws    compute    data:config
     ${result}=    CloudCustodian.Core.Generate Policy   
@@ -28,7 +28,7 @@ Check for stale AWS EC2 instances in AWS Region `${AWS_REGION}` in AWS account `
     ${stale_ec2_instances_score}=    Evaluate    1 if int(${count.stdout}) <= int(${MAX_ALLOWED_STALE_INSTANCES}) else 0
     Set Global Variable    ${stale_ec2_instances_score}
 
-Check for stopped AWS EC2 instances in AWS Region `${AWS_REGION}` in AWS account `${AWS_ACCOUNT_ID}` 
+Check for stopped AWS EC2 instances in AWS Region `${AWS_REGION}` in AWS account `${AWS_ACCOUNT_NAME}` 
     [Documentation]  Check for stopped EC2 instances in AWS Region. 
     [Tags]    ec2    instance    aws    compute    data:config
     ${result}=    CloudCustodian.Core.Generate Policy   
@@ -43,7 +43,7 @@ Check for stopped AWS EC2 instances in AWS Region `${AWS_REGION}` in AWS account
     ${stopped_ec2_instances_score}=    Evaluate    1 if int(${count.stdout}) <= int(${MAX_ALLOWED_STOPPED_INSTANCES}) else 0
     Set Global Variable    ${stopped_ec2_instances_score}
 
-Check for invalid AWS Auto Scaling Groups in AWS Region `${AWS_REGION}` in AWS account `${AWS_ACCOUNT_ID}`
+Check for invalid AWS Auto Scaling Groups in AWS Region `${AWS_REGION}` in AWS account `${AWS_ACCOUNT_NAME}`
     [Documentation]  Check for invalid Auto Scaling Groups.
     [Tags]    asg    aws    compute    data:config
     ${c7n_output}=    RW.CLI.Run Cli
@@ -68,6 +68,10 @@ Suite Initialization
     ${AWS_ACCOUNT_ID}=    RW.Core.Import User Variable   AWS_ACCOUNT_ID
     ...    type=string
     ...    description=AWS Account ID
+    ...    pattern=\w*
+    ${AWS_ACCOUNT_NAME}=    RW.Core.Import User Variable   AWS_ACCOUNT_NAME
+    ...    type=string
+    ...    description=AWS Account Name
     ...    pattern=\w*
     ${aws_credentials}=    RW.Core.Import Secret    aws_credentials
     ...    type=string
@@ -108,6 +112,7 @@ Suite Initialization
     Set Suite Variable    ${AWS_EC2_TAGS}    ${AWS_EC2_TAGS}
     Set Suite Variable    ${AWS_REGION}    ${AWS_REGION}
     Set Suite Variable    ${AWS_ACCOUNT_ID}    ${AWS_ACCOUNT_ID}
+    Set Suite Variable    ${AWS_ACCOUNT_NAME}    ${AWS_ACCOUNT_NAME}
     Set Suite Variable    ${MAX_ALLOWED_STOPPED_INSTANCES}    ${MAX_ALLOWED_STOPPED_INSTANCES}
     Set Suite Variable    ${MAX_ALLOWED_STALE_INSTANCES}    ${MAX_ALLOWED_STALE_INSTANCES}
     Set Suite Variable    ${MAX_ALLOWED_INVALID_ASG}    ${MAX_ALLOWED_INVALID_ASG}

--- a/codebundles/aws-c7n-monitoring-health/.runwhen/templates/aws-c7n-monitoring-health-sli.yaml
+++ b/codebundles/aws-c7n-monitoring-health/.runwhen/templates/aws-c7n-monitoring-health-sli.yaml
@@ -31,6 +31,8 @@ spec:
       value: "{{match_resource.resource.region}}"
     - name: AWS_ACCOUNT_ID
       value: "{{match_resource.resource.account_id}}"
+    - name: AWS_ACCOUNT_NAME
+      value: "{{match_resource.account_name}}"
   secretsProvided:
     {% include "aws-auth.yaml" ignore missing %}
   alerts:

--- a/codebundles/aws-c7n-monitoring-health/.runwhen/templates/aws-c7n-monitoring-health-sli.yaml
+++ b/codebundles/aws-c7n-monitoring-health/.runwhen/templates/aws-c7n-monitoring-health-sli.yaml
@@ -11,7 +11,7 @@ spec:
   displayUnitsShort: ok
   locations:
       - {{default_location}}
-  description: Score AWS Monitoring Health (1 = Healthy, 0 = Unhealthy) by identifying CloudWatch Log Groups without retention period, Cloudtrail that is not multi-region and CloudTrail Trails without CloudWatch Logs in AWS region {{match_resource.resource.region}} and account {{match_resource.resource.account_id}}
+  description: Score AWS Monitoring Health (1 = Healthy, 0 = Unhealthy) by identifying CloudWatch Log Groups without retention period, Cloudtrail that is not multi-region and CloudTrail Trails without CloudWatch Logs in AWS region {{match_resource.resource.region}} and account {{match_resource.account_name}}
   codeBundle:
     {% if repo_url %}
     repoUrl: {{repo_url}}

--- a/codebundles/aws-c7n-monitoring-health/.runwhen/templates/aws-c7n-monitoring-health-slx.yaml
+++ b/codebundles/aws-c7n-monitoring-health/.runwhen/templates/aws-c7n-monitoring-health-slx.yaml
@@ -8,14 +8,14 @@ metadata:
     {% include "common-annotations.yaml" %}
 spec:
   imageURL: https://storage.googleapis.com/runwhen-nonprod-shared-images/icons/aws/Resource-Icons_06072024/Res_Management-Governance/Res_Amazon-CloudWatch_Logs_48.svg
-  alias: AWS CloudWatch Log Health For Region {{match_resource.resource.region}} in Account {{match_resource.resource.account_id}}
-  asMeasuredBy: CloudWatch Log Groups without retention period, Cloudtrail that is not multi-region and CloudTrail Trails without CloudWatch Logs in AWS region {{match_resource.resource.region}} and account {{match_resource.resource.account_id}}
+  alias: AWS CloudWatch Log Health For Region {{match_resource.resource.region}} in Account {{match_resource.account_name}}
+  asMeasuredBy: CloudWatch Log Groups without retention period, Cloudtrail that is not multi-region and CloudTrail Trails without CloudWatch Logs in AWS region {{match_resource.resource.region}} and account {{match_resource.account_name}}
   configProvided:
   - name: SLX_PLACEHOLDER
     value: SLX_PLACEHOLDER
   owners:
   - {{workspace.owner_email}}
-  statement: Identify CloudWatch and CloudTrail configuration or health issues in AWS region {{match_resource.resource.region}} and account {{match_resource.resource.account_id}}
+  statement: Identify CloudWatch and CloudTrail configuration or health issues in AWS region {{match_resource.resource.region}} and account {{match_resource.account_name}}
   additionalContext:
     {% include "aws-hierarchy.yaml" ignore missing %}
     qualified_name: "{{ match_resource.qualified_name | replace(":", "_") }}"

--- a/codebundles/aws-c7n-monitoring-health/.runwhen/templates/aws-c7n-monitoring-health-taskset.yaml
+++ b/codebundles/aws-c7n-monitoring-health/.runwhen/templates/aws-c7n-monitoring-health-taskset.yaml
@@ -8,7 +8,7 @@ metadata:
     {% include "common-annotations.yaml" %}
 spec:
   location: {{default_location}}
-  description: List AWS CloudWatch Log Groups without retention period, Cloudtrail that is not multi-region and CloudTrail Trails without CloudWatch Logs in AWS region {{match_resource.resource.region}} and account {{match_resource.resource.account_id}}
+  description: List AWS CloudWatch Log Groups without retention period, Cloudtrail that is not multi-region and CloudTrail Trails without CloudWatch Logs in AWS region {{match_resource.resource.region}} and account {{match_resource.account_name}}
   codeBundle:
     {% if repo_url %}
     repoUrl: {{repo_url}}

--- a/codebundles/aws-c7n-monitoring-health/.runwhen/templates/aws-c7n-monitoring-health-taskset.yaml
+++ b/codebundles/aws-c7n-monitoring-health/.runwhen/templates/aws-c7n-monitoring-health-taskset.yaml
@@ -26,5 +26,7 @@ spec:
       value: "{{match_resource.resource.region}}"
     - name: AWS_ACCOUNT_ID
       value: "{{match_resource.resource.account_id}}"
+    - name: AWS_ACCOUNT_NAME
+      value: "{{match_resource.account_name}}"
   secretsProvided:
     {% include "aws-auth.yaml" ignore missing %}

--- a/codebundles/aws-c7n-monitoring-health/runbook.robot
+++ b/codebundles/aws-c7n-monitoring-health/runbook.robot
@@ -12,7 +12,7 @@ Library    CloudCustodian.Core
 Suite Setup    Suite Initialization
 
 *** Tasks ***
-List CloudWatch Log Groups Without Retention Period in AWS Region `${AWS_REGION}` in AWS Account `${AWS_ACCOUNT_ID}`
+List CloudWatch Log Groups Without Retention Period in AWS Region `${AWS_REGION}` in AWS Account `${AWS_ACCOUNT_NAME}`
     [Documentation]  List CloudWatch Log Groups Without Retention Period
     [Tags]    aws    cloudwatch    logs    data:config
     ${c7n_output}=    RW.CLI.Run Cli
@@ -51,7 +51,7 @@ List CloudWatch Log Groups Without Retention Period in AWS Region `${AWS_REGION}
         RW.Core.Add Pre To Report    "No CloudWatch Log Groups without retention period found in AWS Region `${AWS_REGION}` in AWS Account `${AWS_ACCOUNT_ID}`"
     END
 
-Check CloudTrail Configuration in AWS Region `${AWS_REGION}` in AWS Account `${AWS_ACCOUNT_ID}`
+Check CloudTrail Configuration in AWS Region `${AWS_REGION}` in AWS Account `${AWS_ACCOUNT_NAME}`
     [Documentation]    Check if CloudTrail exists and is configured for multi-region
     [Tags]    aws    cloudtrail    data:config
     ${c7n_output}=    RW.CLI.Run Cli
@@ -115,7 +115,7 @@ Check CloudTrail Configuration in AWS Region `${AWS_REGION}` in AWS Account `${A
         END
     END
 
- Check for CloudTrail integration with CloudWatch Logs in AWS Region `${AWS_REGION}` in AWS Account `${AWS_ACCOUNT_ID}`
+ Check for CloudTrail integration with CloudWatch Logs in AWS Region `${AWS_REGION}` in AWS Account `${AWS_ACCOUNT_NAME}`
     [Documentation]    Check for CloudTrail integration with CloudWatch Logs
     [Tags]    aws    cloudtrail    cloudwatch    logs    data:config
     ${c7n_output}=    RW.CLI.Run Cli
@@ -160,6 +160,10 @@ Suite Initialization
     ...    type=string
     ...    description=AWS Account ID
     ...    pattern=\w*
+    ${AWS_ACCOUNT_NAME}=    RW.Core.Import User Variable   AWS_ACCOUNT_NAME
+    ...    type=string
+    ...    description=AWS Account Name
+    ...    pattern=\w*
     ${aws_credentials}=    RW.Core.Import Secret    aws_credentials
     ...    type=string
     ...    description=AWS credentials from the workspace (from aws-auth block; e.g. aws:access_key@cli, aws:irsa@cli).
@@ -167,6 +171,7 @@ Suite Initialization
     ${clean_workding_dir}=    RW.CLI.Run Cli    cmd=rm -rf ${OUTPUT_DIR}/aws-c7n-monitoring-health
     Set Suite Variable    ${AWS_REGION}    ${AWS_REGION}
     Set Suite Variable    ${AWS_ACCOUNT_ID}    ${AWS_ACCOUNT_ID}
+    Set Suite Variable    ${AWS_ACCOUNT_NAME}    ${AWS_ACCOUNT_NAME}
     Set Suite Variable    ${aws_credentials}    ${aws_credentials}
     # AWS credentials are provided by the platform from the aws-auth block (runwhen-local);
     # the runtime uses aws_utils to set up the auth environment (IRSA, access key, assume role, etc.).

--- a/codebundles/aws-c7n-monitoring-health/sli.robot
+++ b/codebundles/aws-c7n-monitoring-health/sli.robot
@@ -12,7 +12,7 @@ Library    CloudCustodian.Core
 Suite Setup    Suite Initialization
 
 *** Tasks ***
-Check CloudWatch Log Groups Without Retention Period in AWS Region `${AWS_REGION}` in AWS account `${AWS_ACCOUNT_ID}`
+Check CloudWatch Log Groups Without Retention Period in AWS Region `${AWS_REGION}` in AWS account `${AWS_ACCOUNT_NAME}`
     [Documentation]  Check CloudWatch Log Groups without retention period
     [Tags]    aws    cloudwatch    logs    data:config
     ${c7n_output}=    RW.CLI.Run Cli
@@ -23,7 +23,7 @@ Check CloudWatch Log Groups Without Retention Period in AWS Region `${AWS_REGION
     ${no_retention_score}=    Evaluate    1 if int(${count.stdout}) <= int(${MAX_LOG_GROUPS_ALLOWED}) else 0
     Set Global Variable    ${no_retention_score}
 
-Check if CloudTrail exists and is configured for multi-region in AWS Region `${AWS_REGION}` in AWS Account `${AWS_ACCOUNT_ID}`
+Check if CloudTrail exists and is configured for multi-region in AWS Region `${AWS_REGION}` in AWS Account `${AWS_ACCOUNT_NAME}`
     [Documentation]    Check if CloudTrail exists and is configured for multi-region
     [Tags]    aws    cloudtrail    logs    data:config
     ${c7n_output}=    RW.CLI.Run Cli
@@ -65,8 +65,8 @@ Check if CloudTrail exists and is configured for multi-region in AWS Region `${A
         Set Global Variable    ${cloudtrail_score}
     END
 
-Check CloudTrail Without CloudWatch Logs in AWS Region `${AWS_REGION}` in AWS Account `${AWS_ACCOUNT_ID}`
-    [Documentation]    Check if CloudTrail exists and is configured for multi-region in AWS Region `${AWS_REGION}` in AWS Account `${AWS_ACCOUNT_ID}`
+Check CloudTrail Without CloudWatch Logs in AWS Region `${AWS_REGION}` in AWS Account `${AWS_ACCOUNT_NAME}`
+    [Documentation]    Check if CloudTrail exists and is configured for multi-region in AWS Region `${AWS_REGION}` in AWS Account `${AWS_ACCOUNT_NAME}`
     [Tags]    aws    cloudtrail    cloudwatch    logs    data:config
     ${c7n_output}=    RW.CLI.Run Cli
     ...    cmd=custodian run -r ${AWS_REGION} --output-dir ${OUTPUT_DIR}/aws-c7n-monitoring-health ${CURDIR}/trail-without-cloudwatch-logs.yaml --cache-period 0
@@ -100,6 +100,10 @@ Suite Initialization
     ...    type=string
     ...    description=AWS Account ID
     ...    pattern=\w*
+    ${AWS_ACCOUNT_NAME}=    RW.Core.Import User Variable   AWS_ACCOUNT_NAME
+    ...    type=string
+    ...    description=AWS Account Name
+    ...    pattern=\w*
     ${aws_credentials}=    RW.Core.Import Secret    aws_credentials
     ...    type=string
     ...    description=AWS credentials from the workspace (from aws-auth block; e.g. aws:access_key@cli, aws:irsa@cli).
@@ -125,6 +129,7 @@ Suite Initialization
     ${clean_workding_dir}=    RW.CLI.Run Cli    cmd=rm -rf ${OUTPUT_DIR}/aws-c7n-monitoring-health
     Set Suite Variable    ${AWS_REGION}    ${AWS_REGION}
     Set Suite Variable    ${AWS_ACCOUNT_ID}    ${AWS_ACCOUNT_ID}
+    Set Suite Variable    ${AWS_ACCOUNT_NAME}    ${AWS_ACCOUNT_NAME}
     Set Suite Variable    ${MAX_LOG_GROUPS_ALLOWED}    ${MAX_LOG_GROUPS_ALLOWED}
     Set Suite Variable    ${MAX_CLOUDTRAIL_TRAILS_WITHOUT_CLOUDWATCH_LOGS_ALLOWED}    ${MAX_CLOUDTRAIL_TRAILS_WITHOUT_CLOUDWATCH_LOGS_ALLOWED}
     Set Suite Variable    ${aws_credentials}    ${aws_credentials}

--- a/codebundles/aws-c7n-network-health/.runwhen/templates/aws-c7n-network-health-sli.yaml
+++ b/codebundles/aws-c7n-network-health/.runwhen/templates/aws-c7n-network-health-sli.yaml
@@ -31,6 +31,8 @@ spec:
       value: "{{match_resource.resource.region}}"
     - name: AWS_ACCOUNT_ID
       value: "{{match_resource.resource.account_id}}"
+    - name: AWS_ACCOUNT_NAME
+      value: "{{match_resource.account_name}}"
   secretsProvided:
     {% include "aws-auth.yaml" ignore missing %}
   alerts:

--- a/codebundles/aws-c7n-network-health/.runwhen/templates/aws-c7n-network-health-sli.yaml
+++ b/codebundles/aws-c7n-network-health/.runwhen/templates/aws-c7n-network-health-sli.yaml
@@ -11,7 +11,7 @@ spec:
   displayUnitsShort: ok
   locations:
       - {{default_location}}
-  description: Score Network Health (1 = Healthy, 0 = Unhealty) by identifying publicly accessible security groups, unused Elastic IPs, unused ELBs, and VPCs with flow logs disabled in AWS account {{match_resource.resource.account_id}}
+  description: Score Network Health (1 = Healthy, 0 = Unhealty) by identifying publicly accessible security groups, unused Elastic IPs, unused ELBs, and VPCs with flow logs disabled in AWS account {{match_resource.account_name}}
   codeBundle:
     {% if repo_url %}
     repoUrl: {{repo_url}}

--- a/codebundles/aws-c7n-network-health/.runwhen/templates/aws-c7n-network-health-slx.yaml
+++ b/codebundles/aws-c7n-network-health/.runwhen/templates/aws-c7n-network-health-slx.yaml
@@ -8,14 +8,14 @@ metadata:
     {% include "common-annotations.yaml" %}
 spec:
   imageURL: https://storage.googleapis.com/runwhen-nonprod-shared-images/icons/aws/Resource-Icons_06072024/Res_Networking-Content-Delivery/Res_Amazon-VPC_Virtual-private-cloud-VPC_48.svg
-  alias: AWS Network Health For AWS Account {{match_resource.resource.account_id}}
-  asMeasuredBy: The number of publicly accessible security groups, unused EIPs, unused ELBs, and VPCs with flow logs disabled in AWS account {{match_resource.resource.account_id}}
+  alias: AWS Network Health For AWS Account {{match_resource.account_name}}
+  asMeasuredBy: The number of publicly accessible security groups, unused EIPs, unused ELBs, and VPCs with flow logs disabled in AWS account {{match_resource.account_name}}
   configProvided:
   - name: SLX_PLACEHOLDER
     value: SLX_PLACEHOLDER
   owners:
   - {{workspace.owner_email}}
-  statement: Identify publicly accessible security groups, unused EIPs, unused ELBs, and VPCs with flow logs disabled in the AWS account {{match_resource.resource.account_id}}
+  statement: Identify publicly accessible security groups, unused EIPs, unused ELBs, and VPCs with flow logs disabled in the AWS account {{match_resource.account_name}}
   additionalContext:
     {% include "aws-hierarchy.yaml" ignore missing %}
     qualified_name: "{{ match_resource.qualified_name | replace(":", "_") }}"

--- a/codebundles/aws-c7n-network-health/.runwhen/templates/aws-c7n-network-health-taskset.yaml
+++ b/codebundles/aws-c7n-network-health/.runwhen/templates/aws-c7n-network-health-taskset.yaml
@@ -8,7 +8,7 @@ metadata:
     {% include "common-annotations.yaml" %}
 spec:
   location: {{default_location}}
-  description: List publicly accessible security groups, unused EIPs, unused ELBs, and VPCs with flow logs disabled in the AWS account {{match_resource.resource.account_id}}
+  description: List publicly accessible security groups, unused EIPs, unused ELBs, and VPCs with flow logs disabled in the AWS account {{match_resource.account_name}}
   codeBundle:
     {% if repo_url %}
     repoUrl: {{repo_url}}

--- a/codebundles/aws-c7n-network-health/.runwhen/templates/aws-c7n-network-health-taskset.yaml
+++ b/codebundles/aws-c7n-network-health/.runwhen/templates/aws-c7n-network-health-taskset.yaml
@@ -26,5 +26,7 @@ spec:
       value: "{{match_resource.resource.region}}"
     - name: AWS_ACCOUNT_ID
       value: "{{match_resource.resource.account_id}}"
+    - name: AWS_ACCOUNT_NAME
+      value: "{{match_resource.account_name}}"
   secretsProvided:
     {% include "aws-auth.yaml" ignore missing %}

--- a/codebundles/aws-c7n-network-health/runbook.robot
+++ b/codebundles/aws-c7n-network-health/runbook.robot
@@ -13,7 +13,7 @@ Suite Setup    Suite Initialization
 
 
 *** Tasks ***
-List Publicly Accessible Security Groups in AWS account `${AWS_ACCOUNT_ID}` 
+List Publicly Accessible Security Groups in AWS account `${AWS_ACCOUNT_NAME}` 
     [Documentation]  Find publicly accessible security groups (e.g., "0.0.0.0/0" or "::/0")
     [Tags]    tag    aws    security-group    network    data:config
     CloudCustodian.Core.Generate Policy   
@@ -54,7 +54,7 @@ List Publicly Accessible Security Groups in AWS account `${AWS_ACCOUNT_ID}`
         END
     END
 
-List unused Elastic IPs in AWS account `${AWS_ACCOUNT_ID}`
+List unused Elastic IPs in AWS account `${AWS_ACCOUNT_NAME}`
     [Documentation]  Find unused Elastic IPs that are not associated with any instance or network interface
     [Tags]    aws    eip    network    data:config
     FOR    ${region}    IN    @{AWS_ENABLED_REGIONS}
@@ -94,7 +94,7 @@ List unused Elastic IPs in AWS account `${AWS_ACCOUNT_ID}`
         END
     END
 
-List unused ELBs in AWS account `${AWS_ACCOUNT_ID}`
+List unused ELBs in AWS account `${AWS_ACCOUNT_NAME}`
     [Documentation]  Find unused Application Load Balancers (ALBs) and Network Load Balancers (NLBs) that do not have any associated targets
     [Tags]    aws    elb    network    data:config
     FOR    ${region}    IN    @{AWS_ENABLED_REGIONS}
@@ -134,7 +134,7 @@ List unused ELBs in AWS account `${AWS_ACCOUNT_ID}`
         END
     END
 
-List VPCs with Flow Logs Disabled in AWS account `${AWS_ACCOUNT_ID}`
+List VPCs with Flow Logs Disabled in AWS account `${AWS_ACCOUNT_NAME}`
     [Documentation]  Find VPCs that do not have flow logs enabled
     [Tags]    aws    vpc    network    data:config
     CloudCustodian.Core.Generate Policy   
@@ -185,6 +185,10 @@ Suite Initialization
     ...    type=string
     ...    description=AWS Account ID
     ...    pattern=\w*
+    ${AWS_ACCOUNT_NAME}=    RW.Core.Import User Variable   AWS_ACCOUNT_NAME
+    ...    type=string
+    ...    description=AWS Account Name
+    ...    pattern=\w*
     ${aws_credentials}=    RW.Core.Import Secret    aws_credentials
     ...    type=string
     ...    description=AWS credentials from the workspace (from aws-auth block; e.g. aws:access_key@cli, aws:irsa@cli).
@@ -216,4 +220,5 @@ Suite Initialization
     Set Suite Variable    ${AWS_SECURITY_GROUP_TAGS}    ${AWS_SECURITY_GROUP_TAGS}
     Set Suite Variable    ${AWS_VPC_TAGS}    ${AWS_VPC_TAGS}
     Set Suite Variable    ${AWS_ACCOUNT_ID}    ${AWS_ACCOUNT_ID}
+    Set Suite Variable    ${AWS_ACCOUNT_NAME}    ${AWS_ACCOUNT_NAME}
     Set Suite Variable    ${aws_credentials}    ${aws_credentials}

--- a/codebundles/aws-c7n-network-health/sli.robot
+++ b/codebundles/aws-c7n-network-health/sli.robot
@@ -13,7 +13,7 @@ Suite Setup    Suite Initialization
 
 
 *** Tasks ***
-Check for publicly accessible security groups in AWS account `${AWS_ACCOUNT_ID}`
+Check for publicly accessible security groups in AWS account `${AWS_ACCOUNT_NAME}`
     [Documentation]  Find publicly accessible security groups (e.g., "0.0.0.0/0" or "::/0")
     [Tags]    aws    security-group    network    data:config
     CloudCustodian.Core.Generate Policy   
@@ -32,7 +32,7 @@ Check for publicly accessible security groups in AWS account `${AWS_ACCOUNT_ID}`
     Set Global Variable    ${public_ip_access_score}
 
 
-Check for unused Elastic IPs in AWS account `${AWS_ACCOUNT_ID}`
+Check for unused Elastic IPs in AWS account `${AWS_ACCOUNT_NAME}`
     [Documentation]  Find unused Elastic IPs that are not associated with any instance or network interface
     [Tags]    aws    eip    network    data:config
     ${total_count}=    Set Variable    0
@@ -47,7 +47,7 @@ Check for unused Elastic IPs in AWS account `${AWS_ACCOUNT_ID}`
     ${unattached_eip_score}=    Evaluate    1 if ${total_count} <= int(${MAX_ALLOWED_UNUSED_RESOURCES}) else 0
     Set Global Variable    ${unattached_eip_score}
 
-Check for unused ELBs in AWS account `${AWS_ACCOUNT_ID}`
+Check for unused ELBs in AWS account `${AWS_ACCOUNT_NAME}`
     [Documentation]  Find unused Application Load Balancers (ALBs) and Network Load Balancers (NLBs) that do not have any associated targets
     [Tags]    aws    elb    network    data:config
     ${total_count}=    Set Variable    0
@@ -62,7 +62,7 @@ Check for unused ELBs in AWS account `${AWS_ACCOUNT_ID}`
     ${unused_elb_score}=    Evaluate    1 if ${total_count} <= int(${MAX_ALLOWED_UNUSED_RESOURCES}) else 0
     Set Global Variable    ${unused_elb_score}
 
-Check for VPCs with Flow Logs disabled in AWS account `${AWS_ACCOUNT_ID}`
+Check for VPCs with Flow Logs disabled in AWS account `${AWS_ACCOUNT_NAME}`
     [Documentation]  Find VPCs that do not have Flow Logs enabled
     [Tags]    aws    vpc    network    data:config
     CloudCustodian.Core.Generate Policy   
@@ -94,6 +94,10 @@ Suite Initialization
     ${AWS_ACCOUNT_ID}=    RW.Core.Import User Variable   AWS_ACCOUNT_ID
     ...    type=string
     ...    description=AWS Account ID
+    ...    pattern=\w*
+    ${AWS_ACCOUNT_NAME}=    RW.Core.Import User Variable   AWS_ACCOUNT_NAME
+    ...    type=string
+    ...    description=AWS Account Name
     ...    pattern=\w*
     ${aws_credentials}=    RW.Core.Import Secret    aws_credentials
     ...    type=string
@@ -144,6 +148,7 @@ Suite Initialization
     Set Suite Variable    ${AWS_SECURITY_GROUP_TAGS}    ${AWS_SECURITY_GROUP_TAGS}
     Set Suite Variable    ${AWS_VPC_TAGS}    ${AWS_VPC_TAGS}
     Set Suite Variable    ${AWS_ACCOUNT_ID}    ${AWS_ACCOUNT_ID}
+    Set Suite Variable    ${AWS_ACCOUNT_NAME}    ${AWS_ACCOUNT_NAME}
     Set Suite Variable    ${UNSECURED_SG_THRESHOLD}    ${UNSECURED_SG_THRESHOLD}
     Set Suite Variable    ${aws_credentials}    ${aws_credentials}
     Set Suite Variable    ${DISABLED_FLOW_LOG_THRESHOLD}    ${DISABLED_FLOW_LOG_THRESHOLD}

--- a/codebundles/aws-c7n-rds-health/.runwhen/templates/aws-c7n-rds-health-sli.yaml
+++ b/codebundles/aws-c7n-rds-health/.runwhen/templates/aws-c7n-rds-health-sli.yaml
@@ -11,7 +11,7 @@ spec:
   displayUnitsShort: ok
   locations:
       - {{default_location}}
-  description: Score RDS Health (1 = Healthy, 0 = Unhealty) by identifying RDS instances that are unencrypted, publicly accessible, or have backups disabled in this AWS region {{match_resource.resource.region}} and account {{match_resource.resource.account_id}}
+  description: Score RDS Health (1 = Healthy, 0 = Unhealty) by identifying RDS instances that are unencrypted, publicly accessible, or have backups disabled in this AWS region {{match_resource.resource.region}} and account {{match_resource.account_name}}
   codeBundle:
     {% if repo_url %}
     repoUrl: {{repo_url}}

--- a/codebundles/aws-c7n-rds-health/.runwhen/templates/aws-c7n-rds-health-sli.yaml
+++ b/codebundles/aws-c7n-rds-health/.runwhen/templates/aws-c7n-rds-health-sli.yaml
@@ -31,6 +31,8 @@ spec:
       value: "{{match_resource.resource.region}}"
     - name: AWS_ACCOUNT_ID
       value: "{{match_resource.resource.account_id}}"
+    - name: AWS_ACCOUNT_NAME
+      value: "{{match_resource.account_name}}"
   secretsProvided:
     {% include "aws-auth.yaml" ignore missing %}
   alerts:

--- a/codebundles/aws-c7n-rds-health/.runwhen/templates/aws-c7n-rds-health-slx.yaml
+++ b/codebundles/aws-c7n-rds-health/.runwhen/templates/aws-c7n-rds-health-slx.yaml
@@ -8,8 +8,8 @@ metadata:
     {% include "common-annotations.yaml" %}
 spec:
   imageURL: https://storage.googleapis.com/runwhen-nonprod-shared-images/icons/aws/Resource-Icons_06072024/Res_Database/Res_Amazon-Aurora_Amazon-RDS-Instance_48.svg
-  alias: AWS RDS Health For Region {{match_resource.resource.region}} in Account {{match_resource.resource.account_id}}
-  asMeasuredBy: RDS instance configuration issues (unencrypted, publicly accessible, or have backups disabled) in region {{match_resource.resource.region}} and account {{match_resource.resource.account_id}}
+  alias: AWS RDS Health For Region {{match_resource.resource.region}} in Account {{match_resource.account_name}}
+  asMeasuredBy: RDS instance configuration issues (unencrypted, publicly accessible, or have backups disabled) in region {{match_resource.resource.region}} and account {{match_resource.account_name}}
   configProvided:
   - name: SLX_PLACEHOLDER
     value: SLX_PLACEHOLDER

--- a/codebundles/aws-c7n-rds-health/.runwhen/templates/aws-c7n-rds-health-taskset.yaml
+++ b/codebundles/aws-c7n-rds-health/.runwhen/templates/aws-c7n-rds-health-taskset.yaml
@@ -26,5 +26,7 @@ spec:
       value: "{{match_resource.resource.region}}"
     - name: AWS_ACCOUNT_ID
       value: "{{match_resource.resource.account_id}}"
+    - name: AWS_ACCOUNT_NAME
+      value: "{{match_resource.account_name}}"
   secretsProvided:
     {% include "aws-auth.yaml" ignore missing %}

--- a/codebundles/aws-c7n-rds-health/runbook.robot
+++ b/codebundles/aws-c7n-rds-health/runbook.robot
@@ -12,7 +12,7 @@ Library    CloudCustodian.Core
 Suite Setup    Suite Initialization
 
 *** Tasks ***
-List Unencrypted RDS Instances in AWS Region `${AWS_REGION}` in AWS Account `${AWS_ACCOUNT_ID}`
+List Unencrypted RDS Instances in AWS Region `${AWS_REGION}` in AWS Account `${AWS_ACCOUNT_NAME}`
     [Documentation]  Find unencrypted RDS instances
     [Tags]    aws    rds    database    encryption    data:config
     ${c7n_output}=    RW.CLI.Run Cli
@@ -49,7 +49,7 @@ List Unencrypted RDS Instances in AWS Region `${AWS_REGION}` in AWS Account `${A
     END
 
 
-List Publicly Accessible RDS Instances in AWS Region `${AWS_REGION}` in AWS Account `${AWS_ACCOUNT_ID}`
+List Publicly Accessible RDS Instances in AWS Region `${AWS_REGION}` in AWS Account `${AWS_ACCOUNT_NAME}`
     [Documentation]  Find publicly accessible RDS instances
     [Tags]    aws    rds    database    security    data:config
     ${c7n_output}=    RW.CLI.Run Cli
@@ -85,7 +85,7 @@ List Publicly Accessible RDS Instances in AWS Region `${AWS_REGION}` in AWS Acco
         END
     END
 
-List RDS Instances with Backups Disabled in AWS Region `${AWS_REGION}` in AWS Account `${AWS_ACCOUNT_ID}`
+List RDS Instances with Backups Disabled in AWS Region `${AWS_REGION}` in AWS Account `${AWS_ACCOUNT_NAME}`
     [Documentation]  Identify RDS instances with backups disabled
     [Tags]    aws    rds    database    backups    data:config
     ${c7n_output}=    RW.CLI.Run Cli
@@ -131,6 +131,10 @@ Suite Initialization
     ...    type=string
     ...    description=AWS Account ID
     ...    pattern=\w*
+    ${AWS_ACCOUNT_NAME}=    RW.Core.Import User Variable   AWS_ACCOUNT_NAME
+    ...    type=string
+    ...    description=AWS Account Name
+    ...    pattern=\w*
     ${aws_credentials}=    RW.Core.Import Secret    aws_credentials
     ...    type=string
     ...    description=AWS credentials from the workspace (from aws-auth block; e.g. aws:access_key@cli, aws:irsa@cli).
@@ -138,6 +142,7 @@ Suite Initialization
     ${clean_workding_dir}=    RW.CLI.Run Cli    cmd=rm -rf ${OUTPUT_DIR}/aws-c7n-rds-health
     Set Suite Variable    ${AWS_REGION}    ${AWS_REGION}
     Set Suite Variable    ${AWS_ACCOUNT_ID}    ${AWS_ACCOUNT_ID}
+    Set Suite Variable    ${AWS_ACCOUNT_NAME}    ${AWS_ACCOUNT_NAME}
     Set Suite Variable    ${aws_credentials}    ${aws_credentials}
     # AWS credentials are provided by the platform from the aws-auth block (runwhen-local);
     # the runtime uses aws_utils to set up the auth environment (IRSA, access key, assume role, etc.).

--- a/codebundles/aws-c7n-rds-health/sli.robot
+++ b/codebundles/aws-c7n-rds-health/sli.robot
@@ -12,7 +12,7 @@ Library    CloudCustodian.Core
 Suite Setup    Suite Initialization
 
 *** Tasks ***
-Check for unencrypted RDS instances in AWS Region `${AWS_REGION}` in AWS account `${AWS_ACCOUNT_ID}`
+Check for unencrypted RDS instances in AWS Region `${AWS_REGION}` in AWS account `${AWS_ACCOUNT_NAME}`
     [Documentation]  Find unencrypted RDS instances
     [Tags]    aws    rds    database    encryption    data:config
     ${c7n_output}=    RW.CLI.Run Cli
@@ -23,7 +23,7 @@ Check for unencrypted RDS instances in AWS Region `${AWS_REGION}` in AWS account
     ${unencrypted_rds_score}=    Evaluate    1 if int(${count.stdout}) <= int(${EVENT_THRESHOLD}) else 0
     Set Global Variable    ${unencrypted_rds_score}
 
-Check for publicly accessible RDS instances in AWS Region `${AWS_REGION}` in AWS account `${AWS_ACCOUNT_ID}`
+Check for publicly accessible RDS instances in AWS Region `${AWS_REGION}` in AWS account `${AWS_ACCOUNT_NAME}`
     [Documentation]  Find publicly accessible RDS instances
     [Tags]    aws    rds    database    security    data:config
     ${c7n_output}=    RW.CLI.Run Cli
@@ -34,7 +34,7 @@ Check for publicly accessible RDS instances in AWS Region `${AWS_REGION}` in AWS
     ${publicly_accessible_rds_score}=    Evaluate    1 if int(${count.stdout}) <= int(${EVENT_THRESHOLD}) else 0
     Set Global Variable    ${publicly_accessible_rds_score}
 
-Check for disabled backup RDS instances in AWS Region `${AWS_REGION}` in AWS account `${AWS_ACCOUNT_ID}`
+Check for disabled backup RDS instances in AWS Region `${AWS_REGION}` in AWS account `${AWS_ACCOUNT_NAME}`
     [Documentation]  Find RDS instances with backups disabled
     [Tags]    aws    rds    database    backups    data:config
     ${c7n_output}=    RW.CLI.Run Cli
@@ -62,6 +62,10 @@ Suite Initialization
     ...    type=string
     ...    description=AWS Account ID
     ...    pattern=\w*
+    ${AWS_ACCOUNT_NAME}=    RW.Core.Import User Variable   AWS_ACCOUNT_NAME
+    ...    type=string
+    ...    description=AWS Account Name
+    ...    pattern=\w*
     ${aws_credentials}=    RW.Core.Import Secret    aws_credentials
     ...    type=string
     ...    description=AWS credentials from the workspace (from aws-auth block; e.g. aws:access_key@cli, aws:irsa@cli).
@@ -75,6 +79,7 @@ Suite Initialization
     ${clean_workding_dir}=    RW.CLI.Run Cli    cmd=rm -rf ${OUTPUT_DIR}/aws-c7n-rds-health
     Set Suite Variable    ${AWS_REGION}    ${AWS_REGION}
     Set Suite Variable    ${AWS_ACCOUNT_ID}    ${AWS_ACCOUNT_ID}
+    Set Suite Variable    ${AWS_ACCOUNT_NAME}    ${AWS_ACCOUNT_NAME}
     Set Suite Variable    ${EVENT_THRESHOLD}    ${EVENT_THRESHOLD}
     Set Suite Variable    ${aws_credentials}    ${aws_credentials}
     # AWS credentials are provided by the platform from the aws-auth block (runwhen-local);

--- a/codebundles/aws-c7n-s3-health/.runwhen/templates/aws-c7n-s3-health-sli.yaml
+++ b/codebundles/aws-c7n-s3-health/.runwhen/templates/aws-c7n-s3-health-sli.yaml
@@ -31,5 +31,7 @@ spec:
       value: "{{match_resource.resource.region}}"
     - name: AWS_ACCOUNT_ID
       value: "{{match_resource.resource.account_id}}"
+    - name: AWS_ACCOUNT_NAME
+      value: "{{match_resource.account_name}}"
   secretsProvided:
     {% include "aws-auth.yaml" ignore missing %}

--- a/codebundles/aws-c7n-s3-health/.runwhen/templates/aws-c7n-s3-health-slx.yaml
+++ b/codebundles/aws-c7n-s3-health/.runwhen/templates/aws-c7n-s3-health-slx.yaml
@@ -8,8 +8,8 @@ metadata:
     {% include "common-annotations.yaml" %}
 spec:
   imageURL: https://storage.googleapis.com/runwhen-nonprod-shared-images/icons/aws/s3.png
-  alias: AWS S3 Bucket Health For Region {{match_resource.resource.region}}
-  asMeasuredBy: The number of AWS S3 Buckets in region {{match_resource.resource.region}}
+  alias: AWS S3 Bucket Health For Region {{match_resource.resource.region}} in Account {{match_resource.account_name}}
+  asMeasuredBy: The number of AWS S3 Buckets in region {{match_resource.resource.region}} and account {{match_resource.account_name}}
   configProvided:
   - name: SLX_PLACEHOLDER
     value: SLX_PLACEHOLDER

--- a/codebundles/aws-c7n-s3-health/.runwhen/templates/aws-c7n-s3-health-taskset.yaml
+++ b/codebundles/aws-c7n-s3-health/.runwhen/templates/aws-c7n-s3-health-taskset.yaml
@@ -26,5 +26,7 @@ spec:
       value: "{{match_resource.resource.region}}"
     - name: AWS_ACCOUNT_ID
       value: "{{match_resource.resource.account_id}}"
+    - name: AWS_ACCOUNT_NAME
+      value: "{{match_resource.account_name}}"
   secretsProvided:
     {% include "aws-auth.yaml" ignore missing %}

--- a/codebundles/aws-c7n-s3-health/runbook.robot
+++ b/codebundles/aws-c7n-s3-health/runbook.robot
@@ -60,14 +60,16 @@ Suite Initialization
     ...    type=string
     ...    description=AWS Account ID
     ...    pattern=\w*
+    ${AWS_ACCOUNT_NAME}=    RW.Core.Import User Variable   AWS_ACCOUNT_NAME
+    ...    type=string
+    ...    description=AWS Account Name
+    ...    pattern=\w*
     ${aws_credentials}=    RW.Core.Import Secret    aws_credentials
     ...    type=string
     ...    description=AWS credentials from the workspace (from aws-auth block; e.g. aws:access_key@cli, aws:irsa@cli).
     ...    pattern=\w*
-    ${aws_account_name_query}=       RW.CLI.Run Cli    
-    ...    cmd=aws organizations describe-account --account-id $(aws sts get-caller-identity --query 'Account' --output text) --query "Account.Name" --output text | tr -d '\n'
     ${clean_workding_dir}=    RW.CLI.Run Cli    cmd=rm -rf ${OUTPUT_DIR}/aws-c7n-s3-health         # Note: Clean out the cloud custoding report dir to ensure accurate data
-    Set Suite Variable    ${AWS_ACCOUNT_NAME}    ${aws_account_name_query.stdout}
+    Set Suite Variable    ${AWS_ACCOUNT_NAME}    ${AWS_ACCOUNT_NAME}
     Set Suite Variable    ${AWS_REGION}    ${AWS_REGION}
     Set Suite Variable    ${AWS_ACCOUNT_ID}    ${AWS_ACCOUNT_ID}
     Set Suite Variable    ${aws_credentials}    ${aws_credentials}

--- a/codebundles/aws-c7n-s3-health/sli.robot
+++ b/codebundles/aws-c7n-s3-health/sli.robot
@@ -34,15 +34,16 @@ Suite Initialization
     ...    type=string
     ...    description=AWS Account ID
     ...    pattern=\w*
+    ${AWS_ACCOUNT_NAME}=    RW.Core.Import User Variable   AWS_ACCOUNT_NAME
+    ...    type=string
+    ...    description=AWS Account Name
+    ...    pattern=\w*
     ${aws_credentials}=    RW.Core.Import Secret    aws_credentials
     ...    type=string
     ...    description=AWS credentials from the workspace (from aws-auth block; e.g. aws:access_key@cli, aws:irsa@cli).
     ...    pattern=\w*
-    # This may not work without certain permissions. We might just drop this, but unfortuinately a numberd account ID is less human friendly to include in task titles. 
-    ${aws_account_name_query}=       RW.CLI.Run Cli    
-    ...    cmd=aws organizations describe-account --account-id $(aws sts get-caller-identity --query 'Account' --output text) --query "Account.Name" --output text | tr -d '\n'
     ${clean_workding_dir}=    RW.CLI.Run Cli    cmd=rm -rf ${OUTPUT_DIR}/aws-c7n-s3-health         # Note: Clean out the cloud custoding report dir to ensure accurate data
-    Set Suite Variable    ${AWS_ACCOUNT_NAME}    ${aws_account_name_query.stdout}
+    Set Suite Variable    ${AWS_ACCOUNT_NAME}    ${AWS_ACCOUNT_NAME}
     Set Suite Variable    ${AWS_REGION}    ${AWS_REGION}
     Set Suite Variable    ${AWS_ACCOUNT_ID}    ${AWS_ACCOUNT_ID}
     Set Suite Variable    ${aws_credentials}    ${aws_credentials}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the production container base image and adds new automated multi-arch build/push + tagging logic, which could affect runtime compatibility and release publishing. Also updates multiple AWS codebundles to require/provide `AWS_ACCOUNT_NAME`, which could break runs if that variable isn’t populated by the platform.
> 
> **Overview**
> **Build/release pipeline:** Adds a new `build-push` GitHub Actions workflow that builds native `amd64`/`arm64` images, runs a smoke test, pushes per-arch digests to GHCR, and then merges them into a multi-arch manifest with a new tag scheme (`<ref>-<cc_sha7>-<rt_sha7>` plus aliases like `latest`/`pr-<n>`). Adds a scheduled/manual `release` workflow to generate date-based GitHub releases.
> 
> **Containerization/dev tooling:** Updates the production `Dockerfile` to build from `ghcr.io/runwhen-contrib/rw-base-runtime` (with an overridable `BASE_IMAGE` arg) and splits local dev into a new `Dockerfile.devcontainer`, updating `.devcontainer.json` to use it.
> 
> **AWS codebundles:** Across several `aws-c7n-*` bundles, switches SLX/SLI descriptions and Robot task titles to use the human-friendly `match_resource.account_name`, and threads a new `AWS_ACCOUNT_NAME` config/user variable through templates and suite initialization (removing ad-hoc account-name lookup in some suites).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 62bb9e580586c799edbae4eeed50c0b738cf9e87. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->