### PR TITLE
Move CCV image build into GitHub Actions

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -2,7 +2,7 @@
     "name": "devtools",
     "shutdownAction": "none",
     "build": {
-        "dockerfile": "Dockerfile"
+        "dockerfile": "Dockerfile.devcontainer"
     },
     "updateRemoteUserUID": false,
     "overrideCommand": false,

--- a/.github/workflows/build-all-branches.yaml
+++ b/.github/workflows/build-all-branches.yaml
@@ -1,0 +1,150 @@
+name: Build All Branches
+
+# Manual fan-out: dispatches build-push.yaml against every branch in the
+# repo (or every branch matching a regex). Useful when:
+#
+#   - rw-base-runtime has shipped a new base image and every CCV branch
+#     should be rebuilt against it
+#   - a security fix or runtime contract change needs to propagate
+#     everywhere without waiting for each branch's next push
+#   - you want to validate that all branches still build cleanly
+#
+# Each dispatched run uses the build-push.yaml definition AS IT EXISTS
+# ON THAT BRANCH — this is intentional. Older branches with outdated
+# build workflows will build with their own logic; newer branches with
+# updated workflows get the new behavior. There is no "use main's build
+# workflow against branch X" mode by design.
+#
+# Builds run as separate workflow runs (one per branch), not as nested
+# jobs. Watch them in the Actions tab filtered to "Build And Push".
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch_pattern:
+        description: "Regex applied to branch names. '.*' (default) matches everything."
+        required: false
+        default: ".*"
+        type: string
+      exclude_pattern:
+        description: "Regex to EXCLUDE branches (applied after branch_pattern). Default: stale/.* prefixed branches."
+        required: false
+        default: "^(dependabot/|stale/)"
+        type: string
+      runtime_ref:
+        description: "rw-base-runtime ref each per-branch build should pin to (branch / tag / sha)."
+        required: false
+        default: "main"
+        type: string
+      push:
+        description: "Push the resulting images to GHCR."
+        required: false
+        default: true
+        type: boolean
+      max_parallel:
+        description: "How many per-branch builds to run concurrently. GHA limit is 256 jobs total."
+        required: false
+        default: "5"
+        type: string
+
+# `actions: write` is required for `gh workflow run` to dispatch other workflows.
+permissions:
+  contents: read
+  actions: write
+
+jobs:
+  # ===========================================================================
+  # enumerate — list branches matching the filter, emit them as a JSON
+  # array the matrix job consumes. Paginates the branches API since GHA
+  # repos can exceed the 100/page default.
+  # ===========================================================================
+  enumerate:
+    runs-on: ubuntu-latest
+    outputs:
+      branches: ${{ steps.list.outputs.branches }}
+      count: ${{ steps.list.outputs.count }}
+      max_parallel: ${{ steps.list.outputs.max_parallel }}
+    steps:
+      - name: List branches matching filter
+        id: list
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          INCLUDE: ${{ inputs.branch_pattern }}
+          EXCLUDE: ${{ inputs.exclude_pattern }}
+          MAX_PARALLEL: ${{ inputs.max_parallel }}
+        run: |
+          set -euo pipefail
+
+          all=$(gh api -X GET "repos/${{ github.repository }}/branches" \
+                  --paginate --jq '.[].name')
+
+          # Apply include regex, then exclude regex. `|| true` so an empty
+          # match doesn't fail the pipeline -- we surface a clear message
+          # downstream instead.
+          filtered=$(printf '%s\n' "${all}" | grep -E "${INCLUDE}" || true)
+          if [ -n "${EXCLUDE}" ]; then
+            filtered=$(printf '%s\n' "${filtered}" | grep -Ev "${EXCLUDE}" || true)
+          fi
+
+          if [ -z "${filtered}" ]; then
+            echo "::warning::No branches matched include='${INCLUDE}' exclude='${EXCLUDE}'"
+            echo "branches=[]" >> "$GITHUB_OUTPUT"
+            echo "count=0" >> "$GITHUB_OUTPUT"
+            echo "max_parallel=${MAX_PARALLEL}" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          json=$(printf '%s\n' "${filtered}" | jq -R . | jq -s -c .)
+          count=$(echo "${json}" | jq 'length')
+
+          echo "branches=${json}" >> "$GITHUB_OUTPUT"
+          echo "count=${count}" >> "$GITHUB_OUTPUT"
+          echo "max_parallel=${MAX_PARALLEL}" >> "$GITHUB_OUTPUT"
+
+          {
+            echo "## Branches selected for build (${count})"
+            echo
+            echo "- Include regex: \`${INCLUDE}\`"
+            echo "- Exclude regex: \`${EXCLUDE}\`"
+            echo "- Max parallel: \`${MAX_PARALLEL}\`"
+            echo
+            while IFS= read -r b; do echo "- \`${b}\`"; done <<< "${filtered}"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  # ===========================================================================
+  # dispatch — one matrix leg per branch. Each leg fires `gh workflow run
+  # build-push.yaml --ref <branch>` and exits. The actual build runs as a
+  # separate workflow run on its own runners, in parallel, so we are not
+  # billed for the long tail of each build here.
+  # ===========================================================================
+  dispatch:
+    needs: enumerate
+    if: needs.enumerate.outputs.count != '0'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      max-parallel: 8
+      matrix:
+        branch: ${{ fromJson(needs.enumerate.outputs.branches) }}
+    steps:
+      - name: Dispatch build-push.yaml for ${{ matrix.branch }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: ${{ matrix.branch }}
+          RUNTIME_REF: ${{ inputs.runtime_ref }}
+          PUSH_FLAG: ${{ inputs.push }}
+        run: |
+          set -euo pipefail
+          echo "Dispatching build-push.yaml on '${BRANCH}' (runtime_ref=${RUNTIME_REF}, push=${PUSH_FLAG})"
+
+          # `gh workflow run` uses the workflow definition AS IT EXISTS at
+          # --ref. If a branch is missing build-push.yaml, the call fails;
+          # that's surfaced as a matrix-leg failure and the user is told to
+          # rebase the branch onto a build-push-bearing main.
+          gh workflow run build-push.yaml \
+            --repo "${{ github.repository }}" \
+            --ref "${BRANCH}" \
+            -f runtime_ref="${RUNTIME_REF}" \
+            -f push="${PUSH_FLAG}"
+
+          echo "::notice::Dispatched build-push.yaml on ${BRANCH}"

--- a/.github/workflows/build-push.yaml
+++ b/.github/workflows/build-push.yaml
@@ -1,0 +1,416 @@
+name: Build And Push
+
+# Builds the codecollection image and pushes a multi-arch manifest to GHCR
+# with the tag schema the cc-registry-v2 image catalog expects:
+#
+#     <sanitized-ref>-<cc_sha7>-<rt_sha7>
+#
+# Where:
+#   sanitized-ref = github.ref_name with '/' -> '-' (e.g. "main", "feature-foo", "pr-42")
+#   cc_sha7       = first 7 chars of github.sha (this repo's commit)
+#   rt_sha7       = first 7 chars of rw-base-runtime at `runtime_ref`
+#                   (https://github.com/runwhen-contrib/rw-base-runtime)
+#
+# Architecture
+# ------------
+# The build is split across three jobs so each platform is built natively
+# rather than under QEMU emulation:
+#
+#   prepare        -- compute tag set + push flag + build args ONCE,
+#                     share with downstream jobs so they can't drift
+#   build (matrix) -- one job per platform, each on its own native runner:
+#                       linux/amd64 -> ubuntu-latest
+#                       linux/arm64 -> ubuntu-24.04-arm
+#                     each job:
+#                       1. builds the image natively (no QEMU)
+#                       2. loads it into the local docker daemon
+#                       3. runs the smoke test against the native arch
+#                       4. on push, builds again push-by-digest (no tags)
+#                          and exports the per-platform digest as an artifact
+#   merge          -- pulls the per-platform digests and uses
+#                     `docker buildx imagetools create` to stitch them
+#                     into a single multi-arch manifest under every tag
+#                     prepare computed. Pure registry-side metadata op.
+#
+# Build triggers:
+#   - push to ANY branch  -> produces a CodeCollectionVersion image for that branch
+#   - pull_request to ANY base branch -> produces a "pr-<n>" preview image
+#   - workflow_dispatch  -> manual build (e.g. to validate against a BYO base)
+#
+# We build off non-main branches on purpose: each branch is a candidate CCV
+# the catalog can pin to. Path filters skip rebuilds for pure docs / config
+# diffs.
+#
+# Dockerfile note: this workflow builds the production `Dockerfile`, which
+# uses rw-base-runtime as its base. The repo's `Dockerfile.devcontainer`
+# (referenced by .devcontainer.json) is the local-dev image and is NOT
+# built here.
+
+on:
+  push:
+    branches:
+      - '**'            # all branches; tag pushes (refs/tags/*) are excluded
+    paths-ignore:
+      - '**/*.md'
+      - '**/*.html'
+      - 'LICENSE'
+      - '.gitignore'
+      - '.gitbook.yaml'
+      - '.devcontainer.json'
+      - 'Dockerfile.devcontainer'
+      - 'CHANGELOG.md'
+      - 'CONTRIBUTING.md'
+      - 'README.md'
+      - 'SUMMARY.md'
+      - 'Introduction.md'
+      - 'docs/**'
+  pull_request:
+    # No branches: restriction -> triggers on PRs targeting any base branch
+    paths-ignore:
+      - '**/*.md'
+      - '**/*.html'
+      - 'LICENSE'
+      - '.gitignore'
+      - '.gitbook.yaml'
+      - '.devcontainer.json'
+      - 'Dockerfile.devcontainer'
+      - 'CHANGELOG.md'
+      - 'CONTRIBUTING.md'
+      - 'README.md'
+      - 'SUMMARY.md'
+      - 'Introduction.md'
+      - 'docs/**'
+  workflow_dispatch:
+    inputs:
+      base_image:
+        description: "Base image (FROM ref) to build against. Leave blank to use the Dockerfile default."
+        required: false
+        default: ""
+        type: string
+      runtime_ref:
+        description: "rw-base-runtime ref to embed in the tag suffix (branch / tag / sha). Default: main."
+        required: false
+        default: "main"
+        type: string
+      push:
+        description: "Push the resulting image to GHCR."
+        required: false
+        default: true
+        type: boolean
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE: ${{ github.repository }}
+  # The repo we resolve the rt_sha tag suffix from. MUST match the base
+  # image we FROM in Dockerfile (currently rw-base-runtime).
+  RUNTIME_REPO: runwhen-contrib/rw-base-runtime
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  # ===========================================================================
+  # prepare — single source of truth for the tag set, push flag and build
+  # args so the matrix builds and the final merge job don't drift.
+  # ===========================================================================
+  prepare:
+    runs-on: ubuntu-latest
+    outputs:
+      should_push: ${{ steps.push_flag.outputs.should_push }}
+      tags: ${{ steps.meta.outputs.tags }}
+      canonical_tag: ${{ steps.meta.outputs.canonical_tag }}
+      repo_lc: ${{ steps.meta.outputs.repo_lc }}
+      sanitized_ref: ${{ steps.meta.outputs.sanitized_ref }}
+      cc_sha: ${{ steps.meta.outputs.cc_sha }}
+      rt_sha: ${{ steps.meta.outputs.rt_sha }}
+      runtime_ref: ${{ steps.meta.outputs.runtime_ref }}
+      base_image_arg: ${{ steps.args.outputs.base_image_arg }}
+    steps:
+      - name: Determine push flag
+        id: push_flag
+        run: |
+          case "${{ github.event_name }}" in
+            push|pull_request)
+              echo "should_push=true" >> "$GITHUB_OUTPUT" ;;
+            workflow_dispatch)
+              echo "should_push=${{ inputs.push }}" >> "$GITHUB_OUTPUT" ;;
+            *)
+              echo "should_push=false" >> "$GITHUB_OUTPUT" ;;
+          esac
+
+      - name: Compute tag set
+        id: meta
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUNTIME_REF_INPUT: ${{ inputs.runtime_ref }}
+        run: |
+          set -euo pipefail
+
+          # --- this repo's sha ---
+          cc_sha="${{ github.sha }}"
+          cc_sha7="${cc_sha:0:7}"
+
+          # --- ref name (PRs collapse to "pr-<n>" since github.ref_name on
+          #     pull_request is "<n>/merge", which is useless as an OCI tag) ---
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            ref_name="pr-${{ github.event.pull_request.number }}"
+          else
+            ref_name="${{ github.ref_name }}"
+          fi
+          # OCI tags must match [A-Za-z0-9_.-]{1,128}. Replace '/' with '-'
+          # so refs like "release/1.2" survive.
+          sanitized_ref="$(echo "${ref_name}" | tr '/' '-' | tr -c 'A-Za-z0-9_.-' '-' | sed 's/^-*//;s/-*$//')"
+
+          # --- runtime sha (defaults to rw-base-runtime@main) ---
+          runtime_ref="${RUNTIME_REF_INPUT:-main}"
+          rt_sha="$(gh api "repos/${RUNTIME_REPO}/commits/${runtime_ref}" --jq '.sha')"
+          rt_sha7="${rt_sha:0:7}"
+
+          # --- repo path (GHCR rejects uppercase) ---
+          repo_lc="$(echo "${{ env.REGISTRY }}/${{ env.IMAGE }}" | tr '[:upper:]' '[:lower:]')"
+
+          # --- canonical immutable tag the catalog uses for discovery ---
+          canonical_tag="${sanitized_ref}-${cc_sha7}-${rt_sha7}"
+
+          # --- moving-pointer aliases (re-pointed on every build) ---
+          tags=( "${repo_lc}:${canonical_tag}" )
+          case "${{ github.event_name }}" in
+            push)
+              tags+=( "${repo_lc}:${sanitized_ref}" )
+              if [ "${{ github.ref_name }}" = "main" ]; then
+                tags+=( "${repo_lc}:latest" )
+              fi
+              ;;
+            pull_request)
+              tags+=( "${repo_lc}:pr-${{ github.event.pull_request.number }}" )
+              ;;
+            workflow_dispatch)
+              tags+=( "${repo_lc}:${sanitized_ref}" )
+              ;;
+          esac
+
+          {
+            echo "cc_sha=${cc_sha}"
+            echo "rt_sha=${rt_sha}"
+            echo "runtime_ref=${runtime_ref}"
+            echo "sanitized_ref=${sanitized_ref}"
+            echo "repo_lc=${repo_lc}"
+            echo "canonical_tag=${canonical_tag}"
+            printf 'tags=%s\n' "$(IFS=,; echo "${tags[*]}")"
+          } >> "$GITHUB_OUTPUT"
+
+          {
+            echo "## Will publish"
+            echo
+            for t in "${tags[@]}"; do echo "- \`${t}\`"; done
+            echo
+            echo "- Codecollection sha: \`${cc_sha}\`"
+            echo "- Runtime ref:        \`${runtime_ref}\`"
+            echo "- Runtime sha:        \`${rt_sha}\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Resolve build args
+        id: args
+        env:
+          INPUT_BASE_IMAGE: ${{ inputs.base_image }}
+        run: |
+          set -euo pipefail
+          if [ -n "${INPUT_BASE_IMAGE:-}" ]; then
+            echo "base_image_arg=BASE_IMAGE=${INPUT_BASE_IMAGE}" >> "$GITHUB_OUTPUT"
+          else
+            echo "base_image_arg=" >> "$GITHUB_OUTPUT"
+          fi
+
+  # ===========================================================================
+  # build — parallel native builds. Each matrix leg runs on a runner whose
+  # architecture matches the platform it is building, so there's no QEMU
+  # emulation cost. Smoke test runs on real hardware for each arch.
+  # ===========================================================================
+  build:
+    needs: prepare
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            arch: amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            arch: arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        if: needs.prepare.outputs.should_push == 'true'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # ----------------------------------------------------------------
+      # Phase 1: build natively + load locally so we can exec the smoke
+      # test. Per-arch GHA cache scope -- the two matrix legs run in
+      # parallel on different runners, so they MUST NOT share a scope.
+      # Cache scope is derived from the repo name so this same workflow
+      # template can be dropped into other codecollections without edits.
+      # ----------------------------------------------------------------
+      - name: Build (native, load)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile
+          platforms: ${{ matrix.platform }}
+          load: true
+          tags: ccv:smoke
+          cache-from: type=gha,scope=${{ github.event.repository.name }}-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=${{ github.event.repository.name }}-${{ matrix.arch }}
+          build-args: |
+            ${{ needs.prepare.outputs.base_image_arg }}
+
+      - name: Smoke test image
+        run: |
+          set -euo pipefail
+          # Native-arch exec -- verifies the runtime layer (rw-core-keywords
+          # imports from rw-base-runtime), the codecollection layout landed,
+          # and the worker binary is intact.
+          docker run --rm --entrypoint /bin/bash ccv:smoke -c '
+            set -eux
+            python3 -c "import RW.Core, RW.platform, RW.fetchsecrets, robot"
+            robot --version || true
+            test -d /home/runwhen/codecollection/codebundles
+            test -f /home/runwhen/codecollection/requirements.txt
+            test -x /home/runwhen/worker
+            python3 --version
+          '
+
+      # ----------------------------------------------------------------
+      # Phase 2: only on push -- rebuild push-by-digest. Writes the
+      # platform-specific manifest into the registry WITHOUT human tags.
+      # The merge job assembles the multi-arch manifest from these
+      # digests under the canonical + alias tags.
+      # ----------------------------------------------------------------
+      - name: Build & push by digest
+        id: digest_push
+        if: needs.prepare.outputs.should_push == 'true'
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile
+          platforms: ${{ matrix.platform }}
+          outputs: type=image,name=${{ needs.prepare.outputs.repo_lc }},push-by-digest=true,name-canonical=true,push=true
+          labels: |
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            io.runwhen.codecollection.commit=${{ github.sha }}
+            io.runwhen.runtime.commit=${{ needs.prepare.outputs.rt_sha }}
+            io.runwhen.runtime.ref=${{ needs.prepare.outputs.runtime_ref }}
+          cache-from: type=gha,scope=${{ github.event.repository.name }}-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=${{ github.event.repository.name }}-${{ matrix.arch }}
+          build-args: |
+            ${{ needs.prepare.outputs.base_image_arg }}
+
+      - name: Stage digest for merge job
+        if: needs.prepare.outputs.should_push == 'true'
+        run: |
+          set -euo pipefail
+          mkdir -p /tmp/digests
+          digest="${{ steps.digest_push.outputs.digest }}"
+          # Merge job enumerates files in this dir; filename = digest sans "sha256:"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        if: needs.prepare.outputs.should_push == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ matrix.arch }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  # ===========================================================================
+  # merge — combine the per-arch digests into the final multi-arch manifest
+  # under every tag prepare computed. `buildx imagetools create` is a
+  # registry-side metadata op -- no image rebuild.
+  # ===========================================================================
+  merge:
+    needs: [prepare, build]
+    if: needs.prepare.outputs.should_push == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digests-*
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create multi-arch manifest
+        env:
+          REPO_LC: ${{ needs.prepare.outputs.repo_lc }}
+          TAG_CSV: ${{ needs.prepare.outputs.tags }}
+        run: |
+          set -euo pipefail
+          tag_args=()
+          IFS=',' read -ra TAGS <<< "${TAG_CSV}"
+          for t in "${TAGS[@]}"; do tag_args+=(-t "$t"); done
+
+          digest_args=()
+          for f in /tmp/digests/*; do
+            d="$(basename "$f")"
+            digest_args+=("${REPO_LC}@sha256:${d}")
+          done
+
+          echo "Tags:    ${TAGS[*]}"
+          echo "Digests: ${digest_args[*]}"
+
+          docker buildx imagetools create "${tag_args[@]}" "${digest_args[@]}"
+
+      - name: Inspect resulting manifest
+        env:
+          TAG_CSV: ${{ needs.prepare.outputs.tags }}
+        run: |
+          set -euo pipefail
+          IFS=',' read -ra TAGS <<< "${TAG_CSV}"
+          docker buildx imagetools inspect "${TAGS[0]}"
+
+      - name: Summary
+        env:
+          REPO_LC: ${{ needs.prepare.outputs.repo_lc }}
+          CANONICAL_TAG: ${{ needs.prepare.outputs.canonical_tag }}
+          TAG_CSV: ${{ needs.prepare.outputs.tags }}
+        run: |
+          {
+            echo "## ${{ github.event.repository.name }} build"
+            echo
+            echo "- Event:               \`${{ github.event_name }}\`"
+            echo "- Ref:                 \`${{ github.ref }}\`"
+            echo "- Codecollection sha:  \`${{ github.sha }}\`"
+            echo "- Runtime ref:         \`${{ needs.prepare.outputs.runtime_ref }}\`"
+            echo "- Runtime sha:         \`${{ needs.prepare.outputs.rt_sha }}\`"
+            echo "- Canonical tag:       \`${REPO_LC}:${CANONICAL_TAG}\`"
+            echo "- Pushed:              \`true\`"
+            echo
+            echo "### Published manifest"
+            IFS=',' read -ra TAGS <<< "${TAG_CSV}"
+            for t in "${TAGS[@]}"; do echo "- \`${t}\`"; done
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,5 +1,23 @@
 name: Release (Date-based)
 
+# Cuts a date-based release tag (YYYY-MM-DD.N) via the shared
+# `runwhen-contrib/github-actions/generate-release` composite action,
+# then dispatches build-push.yaml against the newly-created tag so the
+# release ships with an immutable, catalog-discoverable OCI image.
+#
+# Flow:
+#   release        -> generate-release creates tag + GitHub Release,
+#                     exposing the new tag as steps.create_release.outputs.release_tag
+#   build-release  -> `gh workflow run build-push.yaml --ref <tag>`,
+#                     which runs build-push.yaml's workflow_dispatch path
+#                     against the tag, producing an OCI tag of the form
+#                       <sanitized-tag>-<cc_sha7>-<rt_sha7>
+#                     plus the human-readable :<release_tag> alias.
+#
+# The build runs as a SEPARATE workflow run -- this job just dispatches
+# and returns. Track the resulting build under the "Build And Push"
+# workflow filtered by the release tag ref.
+
 on:
   schedule:
     - cron: '0 12 * * 1'
@@ -7,10 +25,14 @@ on:
 
 permissions:
   contents: write
+  # actions: write is needed for `gh workflow run` to dispatch build-push.yaml.
+  actions: write
 
 jobs:
   release:
     runs-on: ubuntu-latest
+    outputs:
+      release_tag: ${{ steps.create_release.outputs.release_tag }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -19,6 +41,37 @@ jobs:
           persist-credentials: true
 
       - name: Create Release
+        id: create_release
         uses: runwhen-contrib/github-actions/generate-release@main
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  build-release-image:
+    needs: release
+    if: needs.release.outputs.release_tag != ''
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch build-push.yaml for ${{ needs.release.outputs.release_tag }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ needs.release.outputs.release_tag }}
+        run: |
+          set -euo pipefail
+          echo "Dispatching build-push.yaml against release tag '${RELEASE_TAG}'"
+
+          # We dispatch with workflow_dispatch (not via the `release:` event
+          # on build-push.yaml) so the chain is observable here and the
+          # tag-set logic in build-push.yaml uses its existing
+          # workflow_dispatch path -- no special-casing needed.
+          gh workflow run build-push.yaml \
+            --repo "${{ github.repository }}" \
+            --ref "${RELEASE_TAG}" \
+            -f push=true
+
+          {
+            echo "## Release image build dispatched"
+            echo
+            echo "- Release tag: \`${RELEASE_TAG}\`"
+            echo "- Build workflow: \`build-push.yaml @ ${RELEASE_TAG}\`"
+            echo "- Track at: ${{ github.server_url }}/${{ github.repository }}/actions/workflows/build-push.yaml"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,34 +1,47 @@
-FROM us-docker.pkg.dev/runwhen-nonprod-shared/public-images/codecollection-devtools:latest
+# Production codecollection image — the CCV image the RunWhen platform pulls.
+#
+# Source FROM the unified rw-base-runtime, which ships:
+#   - Python 3 + the worker binary at /home/runwhen/worker
+#   - rw-core-keywords pip-installed system-wide (RW.Core / RW.platform /
+#     RW.fetchsecrets) and the rw-base-runtime helper scripts at
+#     /home/runwhen/robot-runtime/
+#   - Standard CLI tooling (kubectl, aws, az, gcloud, helm, gh, jq, yq, ...)
+#
+# Source: https://github.com/runwhen-contrib/rw-base-runtime
+#
+# For interactive local development see Dockerfile.devcontainer (referenced
+# by .devcontainer.json). It still uses codecollection-devtools and ships
+# extra dev tooling. The two image families are intentionally separate
+# during the transition; long-term we'll converge.
+#
+# Override at build time to pin a specific runtime sha or test a BYO base:
+#
+#   docker build \
+#     --build-arg BASE_IMAGE=ghcr.io/runwhen-contrib/rw-base-runtime:<sha7> \
+#     ...
+#
+# The CI workflow (.github/workflows/build-push.yaml) resolves the
+# `runtime_ref` dispatch input to an rw-base-runtime commit sha and bakes
+# that sha into the resulting image tag suffix.
+ARG BASE_IMAGE=ghcr.io/runwhen-contrib/rw-base-runtime:latest
+FROM ${BASE_IMAGE}
 USER root
 
 ENV RUNWHEN_HOME=/home/runwhen
 ENV PATH "$PATH:/usr/local/bin:/home/runwhen/.local/bin"
 
-# Set up directories and permissions
 RUN mkdir -p $RUNWHEN_HOME/codecollection
 WORKDIR $RUNWHEN_HOME/codecollection
 
-# Copy files into container with correct ownership
 COPY --chown=runwhen:0 . .
 
-# Check and install requirements if requirements.txt exists
 RUN if [ -f "requirements.txt" ]; then pip install --no-cache-dir -r requirements.txt; else echo "requirements.txt not found, skipping pip install"; fi
 
-# Install additional user packages
-#RUN apt-get update && \
-#    apt-get install -y --no-install-recommends net-tools && \
-#    apt-get clean && \
-#    rm -rf /var/lib/apt/lists/* /var/cache/apt
-
-# Add runwhen user to sudoers with no password prompt
 RUN echo "runwhen ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
 
-# Set RunWhen Temp Dir
 RUN mkdir -p /var/tmp/runwhen && chmod 1777 /var/tmp/runwhen
 ENV TMPDIR=/var/tmp/runwhen
 
-# Adjust permissions for runwhen user
 RUN chown runwhen:0 -R $RUNWHEN_HOME/codecollection
 
-# Switch to runwhen user
 USER runwhen

--- a/Dockerfile.devcontainer
+++ b/Dockerfile.devcontainer
@@ -1,0 +1,34 @@
+FROM us-docker.pkg.dev/runwhen-nonprod-shared/public-images/codecollection-devtools:latest
+USER root
+
+ENV RUNWHEN_HOME=/home/runwhen
+ENV PATH "$PATH:/usr/local/bin:/home/runwhen/.local/bin"
+
+# Set up directories and permissions
+RUN mkdir -p $RUNWHEN_HOME/codecollection
+WORKDIR $RUNWHEN_HOME/codecollection
+
+# Copy files into container with correct ownership
+COPY --chown=runwhen:0 . .
+
+# Check and install requirements if requirements.txt exists
+RUN if [ -f "requirements.txt" ]; then pip install --no-cache-dir -r requirements.txt; else echo "requirements.txt not found, skipping pip install"; fi
+
+# Install additional user packages
+#RUN apt-get update && \
+#    apt-get install -y --no-install-recommends net-tools && \
+#    apt-get clean && \
+#    rm -rf /var/lib/apt/lists/* /var/cache/apt
+
+# Add runwhen user to sudoers with no password prompt
+RUN echo "runwhen ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
+
+# Set RunWhen Temp Dir
+RUN mkdir -p /var/tmp/runwhen && chmod 1777 /var/tmp/runwhen
+ENV TMPDIR=/var/tmp/runwhen
+
+# Adjust permissions for runwhen user
+RUN chown runwhen:0 -R $RUNWHEN_HOME/codecollection
+
+# Switch to runwhen user
+USER runwhen


### PR DESCRIPTION
## Summary

Moves the CodeCollectionVersion (CCV) image build for this repo out of the external build-system pipeline and into GitHub Actions, matching the pattern being rolled out across the codecollection repos.

- **New production `Dockerfile`** based on `ghcr.io/runwhen-contrib/rw-base-runtime:latest`. The runtime base ships the worker binary, Python 3, `rw-core-keywords` system-wide, the helper scripts at `/home/runwhen/robot-runtime/`, and the standard CLI tooling (kubectl, aws, az, gcloud, helm, gh, jq, yq, ...).
- **`Dockerfile.devcontainer`** keeps the existing devcontainer behavior — still uses `codecollection-devtools` for IDE / interactive dev. `.devcontainer.json` now points at it.
- **`.github/workflows/build-push.yaml`**: three-job workflow
  - `prepare` — single source of truth for the tag set / push flag
  - `build` matrix on native runners: `ubuntu-latest` (amd64) + `ubuntu-24.04-arm` (arm64), each with its own GHA cache scope. Builds natively, smoke-tests on real hardware, then pushes by digest.
  - `merge` — assembles the multi-arch manifest via `docker buildx imagetools create` under every tag.
- **Tag schema** matches what `cc-registry-v2`'s OCI image catalog expects: `<sanitized_ref>-<cc_sha7>-<rt_sha7>`, plus moving aliases (`:<branch>`, `:latest` on main, `:pr-<n>` on PRs).
- **Triggers**: push to any branch (CCV per-branch builds), PRs against any base branch, `workflow_dispatch` with overrides for `base_image` / `runtime_ref` / `push`. `paths-ignore` skips docs-only diffs.

Supersedes #31, which had drifted 3 months from `main` and was carrying stale duplicate refactor work already merged to `main` via #28.

## Test plan

- [ ] First push to `ccv/build-pipeline` auto-triggers the workflow
- [ ] Both `build (amd64)` and `build (arm64)` smoke-tests pass on native runners
- [ ] `merge` job publishes multi-arch manifest to `ghcr.io/runwhen-contrib/aws-c7n-codecollection` under the canonical + alias tags
- [ ] Manifest inspect shows two platform entries (linux/amd64, linux/arm64)
- [ ] cc-registry-v2 OCI source discovers the new tag on its next poll


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the production container base image and replaces the image build/release pipeline with new GitHub Actions workflows, which could impact image contents, tagging, and publishing behavior.
> 
> **Overview**
> Shifts the CCV container build from the previous process into GitHub Actions by adding a new `Build And Push` workflow that builds **native amd64/arm64 images**, runs a smoke test, and publishes a multi-arch manifest to GHCR with a canonical `<ref>-<cc_sha7>-<rt_sha7>` tag plus branch/PR/release aliases.
> 
> Updates the production `Dockerfile` to base on `ghcr.io/runwhen-contrib/rw-base-runtime` (with optional `BASE_IMAGE` override) while keeping local dev on the prior tooling via a new `Dockerfile.devcontainer` and `.devcontainer.json` pointing to it.
> 
> Extends `release.yaml` to dispatch an image build for newly created release tags, and adds a manual `build-all-branches.yaml` workflow to fan out `build-push.yaml` runs across many branches (with include/exclude regex and runtime pinning).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d678f5c009a38b2545ca97918da27ed0a78039e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->